### PR TITLE
Issue/57 add header button

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -2,8 +2,11 @@ package org.wordpress.aztec.toolbar
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.MenuItem
 import android.view.View
 import android.widget.FrameLayout
+import android.widget.PopupMenu
+import android.widget.PopupMenu.OnMenuItemClickListener
 import android.widget.Toast
 import android.widget.ToggleButton
 import org.wordpress.aztec.AztecText
@@ -11,9 +14,7 @@ import org.wordpress.aztec.R
 import org.wordpress.aztec.TextFormat
 import java.util.*
 
-
-class AztecToolbar : FrameLayout {
-
+class AztecToolbar : FrameLayout, OnMenuItemClickListener {
     private var mEditor: AztecText? = null
 
     constructor(context: Context) : super(context) {
@@ -28,6 +29,41 @@ class AztecToolbar : FrameLayout {
         initView()
     }
 
+    override fun onMenuItemClick(item: MenuItem?): Boolean {
+        when (item?.itemId) {
+            R.id.header_1 -> {
+                // TODO: Format line for H1
+                Toast.makeText(context, "H1", Toast.LENGTH_SHORT).show()
+                return true
+            }
+            R.id.header_2 -> {
+                // TODO: Format line for H2
+                Toast.makeText(context, "H2", Toast.LENGTH_SHORT).show()
+                return true
+            }
+            R.id.header_3 -> {
+                // TODO: Format line for H3
+                Toast.makeText(context, "H3", Toast.LENGTH_SHORT).show()
+                return true
+            }
+            R.id.header_4 -> {
+                // TODO: Format line for H4
+                Toast.makeText(context, "H4", Toast.LENGTH_SHORT).show()
+                return true
+            }
+            R.id.header_5 -> {
+                // TODO: Format line for H5
+                Toast.makeText(context, "H5", Toast.LENGTH_SHORT).show()
+                return true
+            }
+            R.id.header_6 -> {
+                // TODO: Format line for H6
+                Toast.makeText(context, "H6", Toast.LENGTH_SHORT).show()
+                return true
+            }
+            else -> return false
+        }
+    }
 
     private fun isEditorAttached(): Boolean {
         return mEditor != null && mEditor is AztecText
@@ -73,13 +109,11 @@ class AztecToolbar : FrameLayout {
         return actions
     }
 
-
     private fun toggleButton(button: View?, checked: Boolean) {
         if (button != null && button is ToggleButton) {
             button.isChecked = checked
         }
     }
-
 
     private fun highlightAppliedStyles(selStart: Int, selEnd: Int) {
         if (!isEditorAttached()) return
@@ -95,7 +129,6 @@ class AztecToolbar : FrameLayout {
         mEditor!!.setSelectedStyles(appliedStyles)
         highlightActionButtons(ToolbarAction.getToolbarActionsForStyles(appliedStyles))
     }
-
 
     private fun onToolbarAction(action: ToolbarAction) {
         if (!isEditorAttached()) return
@@ -116,6 +149,7 @@ class AztecToolbar : FrameLayout {
 
         //other toolbar action
         when (action) {
+            ToolbarAction.HEADER -> showHeaderMenu(findViewById(action.buttonId))
             ToolbarAction.LINK -> showLinkDialog()
             ToolbarAction.HTML -> mEditor!!.setText(mEditor!!.toHtml())
             else -> {
@@ -125,10 +159,15 @@ class AztecToolbar : FrameLayout {
 
     }
 
+    private fun showHeaderMenu(view: View) {
+        val popup = PopupMenu(context, view)
+        popup.setOnMenuItemClickListener(this)
+        popup.inflate(R.menu.header)
+        popup.show()
+    }
 
     private fun showLinkDialog() {
         if (!isEditorAttached()) return
         Toast.makeText(context, "Unsupported action", Toast.LENGTH_SHORT).show()
     }
-
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
@@ -9,6 +9,7 @@ import java.util.*
  */
 enum class ToolbarAction constructor(val buttonId: Int, val actionType: ToolbarActionType, val textFormat: TextFormat?) {
     ADD_MEDIA(R.id.format_bar_button_media, ToolbarActionType.OTHER, null),
+    HEADER(R.id.format_bar_button_header, ToolbarActionType.OTHER, null),
     BOLD(R.id.format_bar_button_bold, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_BOLD),
     ITALIC(R.id.format_bar_button_italic, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_ITALIC),
     STRIKETHROUGH(R.id.format_bar_button_strikethrough, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_STRIKETHROUGH),

--- a/aztec/src/main/res/drawable/format_bar_button_header.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header.xml
@@ -1,7 +1,7 @@
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="24.0"
     android:viewportWidth="24.0" >
 

--- a/aztec/src/main/res/drawable/format_bar_button_header.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header.xml
@@ -2,12 +2,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="44dp"
     android:width="44dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0" >
+    android:viewportHeight="44.0"
+    android:viewportWidth="44.0" >
 
     <path
         android:fillColor="#87A6BC"
-        android:pathData="M2.5,4v3h5v12h3L10.5,7h5L15.5,4h-13zM21.5,9h-9v3h3v7h3v-7h3L21.5,9z" >
+        android:pathData="M12.5,14v3h5v12h3V17h5v-3H12.5z M31.5,19h-9v3h3v7h3v-7h3V19z" >
     </path>
 
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_header.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="#87A6BC"
+        android:pathData="M2.5,4v3h5v12h3L10.5,7h5L15.5,4h-13zM21.5,9h-9v3h3v7h3v-7h3L21.5,9z" >
+    </path>
+
+</vector>

--- a/aztec/src/main/res/drawable/format_bar_button_header_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_disabled.xml
@@ -1,7 +1,7 @@
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="24.0"
     android:viewportWidth="24.0" >
 

--- a/aztec/src/main/res/drawable/format_bar_button_header_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_disabled.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="#E8EEF2"
+        android:pathData="M2.5,4v3h5v12h3L10.5,7h5L15.5,4h-13zM21.5,9h-9v3h3v7h3v-7h3L21.5,9z" >
+    </path>
+
+</vector>

--- a/aztec/src/main/res/drawable/format_bar_button_header_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_disabled.xml
@@ -2,12 +2,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="44dp"
     android:width="44dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0" >
+    android:viewportHeight="44.0"
+    android:viewportWidth="44.0" >
 
     <path
         android:fillColor="#E8EEF2"
-        android:pathData="M2.5,4v3h5v12h3L10.5,7h5L15.5,4h-13zM21.5,9h-9v3h3v7h3v-7h3L21.5,9z" >
+        android:pathData="M12.5,14v3h5v12h3V17h5v-3H12.5z M31.5,19h-9v3h3v7h3v-7h3V19z" >
     </path>
 
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_header_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_highlighted.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="#0084BC"
+        android:pathData="M2.5,4v3h5v12h3L10.5,7h5L15.5,4h-13zM21.5,9h-9v3h3v7h3v-7h3L21.5,9z" >
+    </path>
+
+</vector>

--- a/aztec/src/main/res/drawable/format_bar_button_header_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_highlighted.xml
@@ -1,7 +1,7 @@
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
-    android:width="24dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="24.0"
     android:viewportWidth="24.0" >
 

--- a/aztec/src/main/res/drawable/format_bar_button_header_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_highlighted.xml
@@ -2,12 +2,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="44dp"
     android:width="44dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0" >
+    android:viewportHeight="44.0"
+    android:viewportWidth="44.0" >
 
     <path
         android:fillColor="#0084BC"
-        android:pathData="M2.5,4v3h5v12h3L10.5,7h5L15.5,4h-13zM21.5,9h-9v3h3v7h3v-7h3L21.5,9z" >
+        android:pathData="M12.5,14v3h5v12h3V17h5v-3H12.5z M31.5,19h-9v3h3v7h3v-7h3V19z" >
     </path>
 
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_header_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_selector.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_header_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_header_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_header_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_header" />
+
+</selector>

--- a/aztec/src/main/res/layout/format_bar.xml
+++ b/aztec/src/main/res/layout/format_bar.xml
@@ -1,129 +1,156 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:layout_gravity="bottom"
-              android:layout_alignParentBottom="true"
-              android:background="@color/format_bar_background"
-              android:orientation="vertical">
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/format_bar_background"
+    android:layout_alignParentBottom="true"
+    android:layout_gravity="bottom"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:orientation="vertical" >
 
     <View
         android:id="@+id/format_bar_horizontal_divider"
-        android:layout_width="fill_parent"
         android:layout_height="@dimen/format_bar_horizontal_divider_height"
-        style="@style/Divider"/>
+        android:layout_width="fill_parent"
+        style="@style/Divider" >
+    </View>
 
     <LinearLayout
         android:id="@+id/format_bar_buttons"
-        android:layout_width="fill_parent"
-        android:layout_height="@dimen/format_bar_height"
         android:layout_gravity="bottom"
+        android:layout_height="@dimen/format_bar_height"
         android:layout_marginRight="@dimen/format_bar_right_margin"
+        android:layout_width="fill_parent"
         android:orientation="horizontal"
-        tools:ignore="RtlHardcoded">
+        tools:ignore="RtlHardcoded" >
 
         <HorizontalScrollView
-            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginRight="@dimen/format_bar_scroll_right_margin"
             android:layout_weight="1"
-            android:layout_marginRight="@dimen/format_bar_scroll_right_margin">
+            android:layout_width="0dp" >
 
             <LinearLayout
-                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/format_bar_left_margin"
+                android:layout_width="wrap_content"
                 android:orientation="horizontal"
-                tools:ignore="RtlHardcoded">
+                tools:ignore="RtlHardcoded" >
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_media"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
+                    android:background="@drawable/format_bar_button_media_selector"
                     android:contentDescription="@string/format_bar_description_media"
-                    android:background="@drawable/format_bar_button_media_selector"/>
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
+
+                <org.wordpress.aztec.toolbar.RippleToggleButton
+                    android:id="@+id/format_bar_button_header"
+                    android:background="@drawable/format_bar_button_header_selector"
+                    android:contentDescription="@string/format_bar_description_header"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_bold"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_bold"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:contentDescription="@string/format_bar_description_bold"
                     android:background="@drawable/format_bar_button_bold_selector"
-                    android:tag="@string/format_bar_tag_bold"/>
+                    android:contentDescription="@string/format_bar_description_bold"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_bold"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_italic"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:contentDescription="@string/format_bar_description_italic"
                     android:background="@drawable/format_bar_button_italic_selector"
-                    android:tag="@string/format_bar_tag_italic"/>
+                    android:contentDescription="@string/format_bar_description_italic"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_italic"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_strikethrough"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:contentDescription="@string/format_bar_description_italic"
                     android:background="@drawable/format_bar_button_strikethrough_selector"
-                    android:tag="@string/format_bar_tag_strikethrough"/>
-
+                    android:contentDescription="@string/format_bar_description_italic"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_strikethrough"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_quote"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:contentDescription="@string/format_bar_description_quote"
                     android:background="@drawable/format_bar_button_quote_selector"
-                    android:tag="@string/format_bar_tag_blockquote"/>
+                    android:contentDescription="@string/format_bar_description_quote"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_blockquote"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_ul"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:contentDescription="@string/format_bar_description_ul"
                     android:background="@drawable/format_bar_button_ul_selector"
-                    android:tag="@string/format_bar_tag_unorderedList"/>
+                    android:contentDescription="@string/format_bar_description_ul"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_unorderedList"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_ol"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:contentDescription="@string/format_bar_description_ol"
                     android:background="@drawable/format_bar_button_ol_selector"
-                    android:tag="@string/format_bar_tag_orderedList"/>
+                    android:contentDescription="@string/format_bar_description_ol"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_orderedList"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
 
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_link"
-                    style="@style/FormatBarButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="fill_parent"
-                    android:contentDescription="@string/format_bar_description_link"
                     android:background="@drawable/format_bar_button_link_selector"
-                    android:tag="@string/format_bar_tag_link"/>
+                    android:contentDescription="@string/format_bar_description_link"
+                    android:layout_height="fill_parent"
+                    android:layout_width="wrap_content"
+                    android:tag="@string/format_bar_tag_link"
+                    style="@style/FormatBarButton" >
+                </org.wordpress.aztec.toolbar.RippleToggleButton>
+
             </LinearLayout>
+
         </HorizontalScrollView>
 
         <ImageView
-            app:srcCompat="@drawable/format_bar_chevron"
+            android:id="@+id/imageView"
             android:background="@android:color/transparent"
-            android:layout_width="wrap_content"
+            android:contentDescription="@null"
             android:layout_height="wrap_content"
-            android:id="@+id/imageView" />
+            android:layout_width="wrap_content"
+            app:srcCompat="@drawable/format_bar_chevron" >
+        </ImageView>
 
         <org.wordpress.aztec.toolbar.RippleToggleButton
             android:id="@+id/format_bar_button_html"
-            style="@style/FormatBarHtmlButton"
-            android:layout_width="wrap_content"
-            android:layout_height="fill_parent"
+            android:background="@drawable/format_bar_button_html_selector"
             android:contentDescription="@string/format_bar_description_html"
-            android:background="@drawable/format_bar_button_html_selector"/>
+            android:layout_height="fill_parent"
+            android:layout_width="wrap_content"
+            style="@style/FormatBarHtmlButton" >
+        </org.wordpress.aztec.toolbar.RippleToggleButton>
+
     </LinearLayout>
+
 </LinearLayout>

--- a/aztec/src/main/res/menu/header.xml
+++ b/aztec/src/main/res/menu/header.xml
@@ -1,0 +1,34 @@
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item
+        android:id="@+id/header_1"
+        android:title="@string/header_1" >
+    </item>
+
+    <item
+        android:id="@+id/header_2"
+        android:title="@string/header_2" >
+    </item>
+
+    <item
+        android:id="@+id/header_3"
+        android:title="@string/header_3" >
+    </item>
+
+    <item
+        android:id="@+id/header_4"
+        android:title="@string/header_4" >
+    </item>
+
+    <item
+        android:id="@+id/header_5"
+        android:title="@string/header_5" >
+    </item>
+
+    <item
+        android:id="@+id/header_6"
+        android:title="@string/header_6" >
+    </item>
+
+</menu>

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="format_bar_tag_link" translatable="false">link</string>
 
     <!-- Accessibility - format bar button descriptions -->
+    <string name="format_bar_description_header">Header</string>
     <string name="format_bar_description_bold">Bold</string>
     <string name="format_bar_description_italic">Italic</string>
     <string name="format_bar_description_underline">Underline</string>

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -1,4 +1,12 @@
 <resources>
+
+    <!-- DIALOG -->
+    <string name="dialog_title">Insert link</string>
+    <string name="dialog_edit_hint">http(s)://</string>
+    <string name="dialog_button_ok">OK</string>
+    <string name="dialog_button_cancel">Cancel</string>
+
+    <!-- FORMAT -->
     <string name="format_bar_tag_bold" translatable="false">bold</string>
     <string name="format_bar_tag_italic" translatable="false">italic</string>
     <string name="format_bar_tag_blockquote" translatable="false">blockquote</string>
@@ -6,8 +14,6 @@
     <string name="format_bar_tag_orderedList" translatable="false">orderedList</string>
     <string name="format_bar_tag_strikethrough" translatable="false">strikeThrough</string>
     <string name="format_bar_tag_link" translatable="false">link</string>
-
-    <!-- Accessibility - format bar button descriptions -->
     <string name="format_bar_description_header">Header</string>
     <string name="format_bar_description_bold">Bold</string>
     <string name="format_bar_description_italic">Italic</string>
@@ -23,20 +29,17 @@
     <string name="visual_editor">Visual toolbarActionListener</string>
     <string name="image_thumbnail">Image thumbnail</string>
 
-    <!-- link view -->
+    <!-- HEADER -->
+    <string name="header_1">Header 1</string>
+    <string name="header_2">Header 2</string>
+    <string name="header_3">Header 3</string>
+    <string name="header_4">Header 4</string>
+    <string name="header_5">Header 5</string>
+    <string name="header_6">Header 6</string>
+
+    <!-- LINK -->
     <string name="link_enter_url">URL</string>
     <string name="link_enter_url_text">Link text (optional)</string>
     <string name="create_a_link">Create a link</string>
-
-    <string name="ok">OK</string>
-    <string name="cancel">Cancel</string>
-    <string name="delete">Delete</string>
-
-
-    <!-- Dialog -->
-    <string name="dialog_title">Insert link</string>
-    <string name="dialog_edit_hint">http(s)://</string>
-    <string name="dialog_button_ok">OK</string>
-    <string name="dialog_button_cancel">Cancel</string>
 
 </resources>


### PR DESCRIPTION
### Fix
Add header button to format bar as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/57.

### Test
1. Open app.
2. Tap header button.
3. Tap menu item.