### PR TITLE
Issue/45 list newline support

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1111,7 +1111,7 @@ class AztecText : EditText, TextWatcher {
 
         //we might need to open span to add text to it
         if (spanToOpen != null) {
-            var spanEnd = text.getSpanEnd(spanToOpen) + textChangedEvent.count
+            val spanEnd = text.getSpanEnd(spanToOpen) + textChangedEvent.count
 
             if (spanEnd <= text.length) {
                 editableText.setSpan(spanToOpen,

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -135,8 +135,7 @@ class AztecText : EditText, TextWatcher {
         if (state != null && state is Bundle) {
             removedSpans = state.getIntegerArrayList(REMOVED_SPANS_BUNDLE_KEY)
             super.onRestoreInstanceState(state.getParcelable(SUPER_STATE_BUNDLE_KEY))
-        }
-        else {
+        } else {
             super.onRestoreInstanceState(BaseSavedState.EMPTY_STATE)
         }
     }
@@ -1112,10 +1111,14 @@ class AztecText : EditText, TextWatcher {
 
         //we might need to open span to add text to it
         if (spanToOpen != null) {
-            editableText.setSpan(spanToOpen,
-                    text.getSpanStart(spanToOpen),
-                    text.getSpanEnd(spanToOpen) + textChangedEvent.count,
-                    Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+            var spanEnd = text.getSpanEnd(spanToOpen) + textChangedEvent.count
+
+            if (spanEnd <= text.length) {
+                editableText.setSpan(spanToOpen,
+                        text.getSpanStart(spanToOpen),
+                        spanEnd,
+                        Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+            }
         }
 
 
@@ -1252,6 +1255,7 @@ class AztecText : EditText, TextWatcher {
         switchToAztecStyle(builder, 0, builder.length)
         disableTextChangedListener()
         text = builder
+        enableTextChangedListener()
     }
 
     fun toHtml(): String {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/BulletListTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/BulletListTest.kt
@@ -218,7 +218,6 @@ class BulletListTest() {
     }
 
 
-    //ToDo: Make empty bullet points work
     @Test
     @Throws(Exception::class)
     fun emptyBulletSurroundedBytItems() {
@@ -236,5 +235,29 @@ class BulletListTest() {
         Assert.assertEquals("<ul><li>first item</li><li></li><li>third item</li></ul>", editText.toHtml())
     }
 
+
+    @Test
+    @Throws(Exception::class)
+    fun trailingEmptyBulletPoint() {
+        editText.toggleFormatting(TextFormat.FORMAT_BULLET)
+        editText.append("first item")
+        editText.append("\n")
+        editText.append("second item")
+        editText.append("\n")
+        editText.append("third item")
+        val mark = editText.length()
+        editText.append("\n")
+
+        Assert.assertEquals("<ul><li>first item</li><li>second item</li><li>third item</li><li></li></ul>", editText.toHtml())
+        editText.append("\n")
+
+        Assert.assertEquals("<ul><li>first item</li><li>second item</li><li>third item</li></ul>", editText.toHtml())
+
+        editText.append("not in list")
+        editText.setSelection(mark)
+        editText.text.insert(mark,"\n")
+        Assert.assertEquals("<ul><li>first item</li><li>second item</li><li>third item</li><li></li></ul>not in list", editText.toHtml())
+
+    }
 
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/BulletListTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/BulletListTest.kt
@@ -219,22 +219,22 @@ class BulletListTest() {
 
 
     //ToDo: Make empty bullet points work
-//    @Test
-//    @Throws(Exception::class)
-//    fun emptyBulletSurroundedBytItems() {
-//        editText.bullet(!editText.contains(AztecText.FORMAT_BULLET))
-//        editText.append("first item")
-//        editText.append("\n")
-//        val firstMark = editText.length()
-//        editText.append("second item")
-//        editText.append("\n")
-//        val secondMart = editText.length()
-//        editText.append("third item")
-//
-//        editText.text.delete(firstMark-1,secondMart-2)
-//
-//        Assert.assertEquals("<ul><li>first item</li><li></li><li>third item</li></ul>", editText.toHtml())
-//    }
+    @Test
+    @Throws(Exception::class)
+    fun emptyBulletSurroundedBytItems() {
+        editText.toggleFormatting(TextFormat.FORMAT_BULLET)
+        editText.append("first item")
+        editText.append("\n")
+        val firstMark = editText.length()
+        editText.append("second item")
+        editText.append("\n")
+        val secondMart = editText.length()
+        editText.append("third item")
+
+        editText.text.delete(firstMark-1,secondMart-2)
+
+        Assert.assertEquals("<ul><li>first item</li><li></li><li>third item</li></ul>", editText.toHtml())
+    }
 
 
 }


### PR DESCRIPTION
This PR adds support for empty elements (`<li></li>`) inside lists.

Fixes #45 