### PR TITLE
Update format toolbar HTML button

### DIFF
--- a/aztec/src/main/res/drawable/format_bar_button_html.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_html.xml
@@ -1,18 +1,13 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="44dp"
-        android:height="44dp"
-        android:viewportWidth="44.0"
-        android:viewportHeight="44.0">
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="44dp"
+    android:width="44dp"
+    android:viewportHeight="44.0"
+    android:viewportWidth="44.0" >
+
     <path
-        android:pathData="M13.93,26H12.79v-4.16H9.17V26H8.04v-9h1.13v3.87h3.62V17h1.14V26z"
-        android:fillColor="#A6BCCC"/>
-    <path
-        android:pathData="M20.97,17.97H18.6V26h-1.13v-8.03h-2.36V17h5.86V17.97z"
-        android:fillColor="#A6BCCC"/>
-    <path
-        android:pathData="M23.75,17l2.35,7.34L28.45,17h1.46v9h-1.13v-3.51l0.1,-3.51L26.53,26h-0.87l-2.34,-6.99l0.1,3.49V26h-1.13v-9H23.75z"
-        android:fillColor="#A6BCCC"/>
-    <path
-        android:pathData="M33,25.03h3.53V26h-4.67v-9h1.14V25.03z"
-        android:fillColor="#A6BCCC"/>
+        android:fillColor="#A6BCCC"
+        android:pathData="M19.4,26.6L14.8,22l4.6-4.6L18,16l-6,6l6,6L19.4,26.6z M24.6,26.6l4.6-4.6l-4.6-4.6L26,16l6,6l-6,6C26,28,24.6,26.6,24.6,26.6z" >
+    </path>
+
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_html_disabled.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_html_disabled.xml
@@ -1,18 +1,13 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="44dp"
-        android:height="44dp"
-        android:viewportWidth="44.0"
-        android:viewportHeight="44.0">
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="44dp"
+    android:width="44dp"
+    android:viewportHeight="44.0"
+    android:viewportWidth="44.0" >
+
     <path
-        android:pathData="M13.93,26H12.79v-4.16H9.17V26H8.04v-9h1.13v3.87h3.62V17h1.14V26z"
-        android:fillColor="#E8EEF2"/>
-    <path
-        android:pathData="M20.97,17.97H18.6V26h-1.13v-8.03h-2.36V17h5.86V17.97z"
-        android:fillColor="#E8EEF2"/>
-    <path
-        android:pathData="M23.75,17l2.35,7.34L28.45,17h1.46v9h-1.13v-3.51l0.1,-3.51L26.53,26h-0.87l-2.34,-6.99l0.1,3.49V26h-1.13v-9H23.75z"
-        android:fillColor="#E8EEF2"/>
-    <path
-        android:pathData="M33,25.03h3.53V26h-4.67v-9h1.14V25.03z"
-        android:fillColor="#E8EEF2"/>
+        android:fillColor="#E8EEF2"
+        android:pathData="M19.4,26.6L14.8,22l4.6-4.6L18,16l-6,6l6,6L19.4,26.6z M24.6,26.6l4.6-4.6l-4.6-4.6L26,16l6,6l-6,6C26,28,24.6,26.6,24.6,26.6z" >
+    </path>
+
 </vector>

--- a/aztec/src/main/res/drawable/format_bar_button_html_highlighted.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_html_highlighted.xml
@@ -1,19 +1,13 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="44dp"
-        android:height="44dp"
-        android:viewportWidth="44.0"
-        android:viewportHeight="44.0">
-    <path android:fillColor="#E1EBF1" android:pathData="M0,0h44v44h-44z"/>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="44dp"
+    android:width="44dp"
+    android:viewportHeight="44.0"
+    android:viewportWidth="44.0" >
+
     <path
-        android:pathData="M13.93,26H12.79v-4.16H9.17V26H8.04v-9h1.13v3.87h3.62V17h1.14V26z"
-        android:fillColor="#A6BCCC"/>
-    <path
-        android:pathData="M20.97,17.97H18.6V26h-1.13v-8.03h-2.36V17h5.86V17.97z"
-        android:fillColor="#A6BCCC"/>
-    <path
-        android:pathData="M23.75,17l2.35,7.34L28.45,17h1.46v9h-1.13v-3.51l0.1,-3.51L26.53,26h-0.87l-2.34,-6.99l0.1,3.49V26h-1.13v-9H23.75z"
-        android:fillColor="#A6BCCC"/>
-    <path
-        android:pathData="M33,25.03h3.53V26h-4.67v-9h1.14V25.03z"
-        android:fillColor="#A6BCCC"/>
+        android:fillColor="#0084BC"
+        android:pathData="M19.4,26.6L14.8,22l4.6-4.6L18,16l-6,6l6,6L19.4,26.6z M24.6,26.6l4.6-4.6l-4.6-4.6L26,16l6,6l-6,6C26,28,24.6,26.6,24.6,26.6z" >
+    </path>
+
 </vector>


### PR DESCRIPTION
### Fix
Update HTML toggle button from `HTML` text to `< >` icon taken from https://design.google.com/icons/#ic_code as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/64.