### PR TITLE
Issue/66 add toolbar hints

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
@@ -5,17 +5,18 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.util.AttributeSet
 import android.view.MotionEvent
+import android.view.View
+import android.view.View.OnLongClickListener
+import android.widget.Toast
 import android.widget.ToggleButton
 import org.wordpress.aztec.R
 
-class RippleToggleButton : ToggleButton {
-
+class RippleToggleButton : ToggleButton, OnLongClickListener {
     private var mHalfWidth: Float = 0.toFloat()
     private var mAnimationIsRunning = false
     private var mTimer = 0
     private var mFillPaint: Paint? = null
     private var mStrokePaint: Paint? = null
-
 
     constructor(context: Context) : super(context) {
         init()
@@ -29,11 +30,12 @@ class RippleToggleButton : ToggleButton {
         init()
     }
 
-
     private fun init() {
         if (isInEditMode) {
             return
         }
+
+        setOnLongClickListener(this)
 
         val rippleColor = resources.getColor(R.color.format_bar_ripple_animation)
 
@@ -73,6 +75,11 @@ class RippleToggleButton : ToggleButton {
 
             invalidate()
         }
+    }
+
+    override fun onLongClick(view: View?): Boolean {
+        Toast.makeText(context, contentDescription, Toast.LENGTH_SHORT).show()
+        return true
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/RippleToggleButton.kt
@@ -78,8 +78,13 @@ class RippleToggleButton : ToggleButton, OnLongClickListener {
     }
 
     override fun onLongClick(view: View?): Boolean {
-        Toast.makeText(context, contentDescription, Toast.LENGTH_SHORT).show()
-        return true
+        if (contentDescription == null ||
+            contentDescription.toString().equals("", ignoreCase = true)) {
+            return false
+        } else {
+            Toast.makeText(context, contentDescription, Toast.LENGTH_SHORT).show()
+            return true
+        }
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/aztec/src/main/res/layout/format_bar.xml
+++ b/aztec/src/main/res/layout/format_bar.xml
@@ -82,7 +82,7 @@
                 <org.wordpress.aztec.toolbar.RippleToggleButton
                     android:id="@+id/format_bar_button_strikethrough"
                     android:background="@drawable/format_bar_button_strikethrough_selector"
-                    android:contentDescription="@string/format_bar_description_italic"
+                    android:contentDescription="@string/format_bar_description_strike"
                     android:layout_height="fill_parent"
                     android:layout_width="wrap_content"
                     android:tag="@string/format_bar_tag_strikethrough"

--- a/aztec/src/main/res/values/strings.xml
+++ b/aztec/src/main/res/values/strings.xml
@@ -21,12 +21,12 @@
     <string name="format_bar_description_underline">Underline</string>
     <string name="format_bar_description_strike">Strikethrough</string>
     <string name="format_bar_description_quote">Block quote</string>
-    <string name="format_bar_description_link">Insert link</string>
-    <string name="format_bar_description_more">Insert more</string>
-    <string name="format_bar_description_media">Insert media</string>
+    <string name="format_bar_description_link">Link</string>
+    <string name="format_bar_description_more">More</string>
+    <string name="format_bar_description_media">Media</string>
     <string name="format_bar_description_ul">Unordered list</string>
     <string name="format_bar_description_ol">Ordered list</string>
-    <string name="format_bar_description_html">HTML mode</string>
+    <string name="format_bar_description_html">HTML</string>
     <string name="visual_editor">Visual toolbarActionListener</string>
     <string name="image_thumbnail">Image thumbnail</string>
 


### PR DESCRIPTION
### Fix
Add a hint message when a format toolbar button is long-pressed as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/66.  The message is the content description of the button.

### Test
1. Long-press a format button.
2. Notice hint message.