### PR TITLE
Add quote span styling for all selected lines

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -834,10 +834,11 @@ class AztecText : EditText, TextWatcher {
 
             var quoteStart = 0
             var quoteEnd = 0
-            if (lineStart <= selectionStart && selectionEnd <= lineEnd) {
-                quoteStart = lineStart
-                quoteEnd = lineEnd
-            } else if (selectionStart <= lineStart && lineEnd <= selectionEnd) {
+
+            if ((lineStart <= selectionStart && selectionEnd <= lineEnd) ||
+                (lineStart >= selectionStart && selectionEnd >= lineEnd) ||
+                (lineStart <= selectionStart && selectionEnd >= lineEnd && selectionStart <= lineEnd) ||
+                (lineStart >= selectionStart && selectionEnd <= lineEnd && selectionEnd >= lineStart)) {
                 quoteStart = lineStart
                 quoteEnd = lineEnd
             }
@@ -868,10 +869,11 @@ class AztecText : EditText, TextWatcher {
 
             var quoteStart = 0
             var quoteEnd = 0
-            if (lineStart <= selectionStart && selectionEnd <= lineEnd) {
-                quoteStart = lineStart
-                quoteEnd = lineEnd
-            } else if (selectionStart <= lineStart && lineEnd <= selectionEnd) {
+
+            if ((lineStart <= selectionStart && selectionEnd <= lineEnd) ||
+                (lineStart >= selectionStart && selectionEnd >= lineEnd) ||
+                (lineStart <= selectionStart && selectionEnd >= lineEnd && selectionStart <= lineEnd) ||
+                (lineStart >= selectionStart && selectionEnd <= lineEnd && selectionEnd >= lineStart)) {
                 quoteStart = lineStart
                 quoteEnd = lineEnd
             }


### PR DESCRIPTION
### Fix
Both partially and fully selected lines are styled when tapping the _Quote_ format button as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/75.

### Test
1. Select multiple lines partially.
2. Tap Quote format button
3. Notice styled lines.