### PR TITLE
Issue/improved copy paste

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -17,6 +17,8 @@
 
 package org.wordpress.aztec
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Typeface
 import android.support.v4.content.ContextCompat
@@ -57,7 +59,6 @@ class AztecText : EditText, TextWatcher {
     private val selectedStyles = ArrayList<TextFormat>()
 
     private var isNewStyleSelected = false
-    private var textWasPasted = false
 
     lateinit var history: History
 
@@ -1312,14 +1313,6 @@ class AztecText : EditText, TextWatcher {
     }
 
     fun handleInlineStyling(text: Editable, textChangedEvent: TextChangedEvent) {
-        //if text is pasted do nothing, except for optimizing inline spans
-        if (textWasPasted) {
-            switchToAztecStyle(text, textChangedEvent.inputStart, textChangedEvent.inputStart + textChangedEvent.count)
-            joinStyleSpans(0, text.length) //TODO: see how this affects performance
-            textWasPasted = false
-            return
-        }
-
         //because we use SPAN_INCLUSIVE_INCLUSIVE for inline styles
         //we need to make sure unselected styles are not applied
         clearInlineStyles(textChangedEvent.inputStart, textChangedEvent.inputEnd, textChangedEvent.isNewLine())
@@ -1589,10 +1582,74 @@ class AztecText : EditText, TextWatcher {
         enableTextChangedListener()
     }
 
+    //logic party copied from TextView
     override fun onTextContextMenuItem(id: Int): Boolean {
-        when (id) {
-            android.R.id.paste -> textWasPasted = true
+        var min = 0
+        var max = text.length
+
+        if (isFocused) {
+            val selStart = selectionStart
+            val selEnd = selectionEnd
+
+            min = Math.max(0, Math.min(selStart, selEnd))
+            max = Math.max(0, Math.max(selStart, selEnd))
         }
-        return super.onTextContextMenuItem(id)
+
+        when (id) {
+            android.R.id.paste -> paste(min, max)
+            android.R.id.copy -> {
+                copy()
+                clearFocus() //hide text action menu
+            }
+            android.R.id.cut -> {
+                copy()
+                text.delete(min, max) //this will hide text action menu
+            }
+            else -> return super.onTextContextMenuItem(id)
+        }
+
+        return true
     }
+
+    //Convert selected text to html and add it to clipboard
+    fun copy() {
+        val selectedText = text.subSequence(selectionStart, selectionEnd)
+        val parser = AztecParser()
+        val output = SpannableStringBuilder(selectedText)
+
+        //Strip block elements untill we figure out copy paste completely
+        output.getSpans(0, output.length, ParagraphStyle::class.java).forEach { output.removeSpan(it) }
+
+        BaseInputConnection.removeComposingSpans(output)
+        val html = Format.clearFormatting(parser.toHtml(output))
+
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+        clipboard.primaryClip = ClipData.newPlainText(null, html)
+    }
+
+
+    //copied from TextView with some changes
+    private fun paste(min: Int, max: Int) {
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = clipboard.primaryClip
+        if (clip != null) {
+            val parser = AztecParser()
+
+            for (i in 0..clip.itemCount - 1) {
+                val textToPaste = clip.getItemAt(i).coerceToText(context)
+
+                val builder = SpannableStringBuilder()
+                builder.append(parser.fromHtml(Format.clearFormatting(textToPaste.toString()), context).trim())
+                Selection.setSelection(text, max)
+
+                disableTextChangedListener()
+                text.replace(min, max, builder)
+                enableTextChangedListener()
+
+                joinStyleSpans(0, text.length) //TODO: see how this affects performance
+            }
+        }
+    }
+
+
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1551,14 +1551,6 @@ class AztecText : EditText, TextWatcher {
             editable.removeSpan(span)
             editable.setSpan(AztecURLSpan(span.url, linkColor, linkUnderline), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
-
-        val strikeThroughSpans = editable.getSpans(start, end, StrikethroughSpan::class.java)
-        for (span in strikeThroughSpans) {
-            val spanStart = editable.getSpanStart(span)
-            val spanEnd = editable.getSpanEnd(span)
-            editable.removeSpan(span)
-            editable.setSpan(AztecStrikethroughSpan(), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
     }
 
     fun disableTextChangedListener() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1580,21 +1580,18 @@ class AztecText : EditText, TextWatcher {
         var max = text.length
 
         if (isFocused) {
-            val selStart = selectionStart
-            val selEnd = selectionEnd
-
-            min = Math.max(0, Math.min(selStart, selEnd))
-            max = Math.max(0, Math.max(selStart, selEnd))
+            min = Math.max(0, Math.min(selectionStart, selectionEnd))
+            max = Math.max(0, Math.max(selectionStart, selectionEnd))
         }
 
         when (id) {
-            android.R.id.paste -> paste(min, max)
+            android.R.id.paste -> paste(text, min, max)
             android.R.id.copy -> {
-                copy()
+                copy(text, min, max)
                 clearFocus() //hide text action menu
             }
             android.R.id.cut -> {
-                copy()
+                copy(text, min, max)
                 text.delete(min, max) //this will hide text action menu
             }
             else -> return super.onTextContextMenuItem(id)
@@ -1604,8 +1601,8 @@ class AztecText : EditText, TextWatcher {
     }
 
     //Convert selected text to html and add it to clipboard
-    fun copy() {
-        val selectedText = text.subSequence(selectionStart, selectionEnd)
+    fun copy(editable: Editable, start: Int, end: Int) {
+        val selectedText = editable.subSequence(start, end)
         val parser = AztecParser()
         val output = SpannableStringBuilder(selectedText)
 
@@ -1621,7 +1618,7 @@ class AztecText : EditText, TextWatcher {
 
 
     //copied from TextView with some changes
-    private fun paste(min: Int, max: Int) {
+    private fun paste(editable: Editable, min: Int, max: Int) {
         val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         val clip = clipboard.primaryClip
         if (clip != null) {
@@ -1632,13 +1629,13 @@ class AztecText : EditText, TextWatcher {
 
                 val builder = SpannableStringBuilder()
                 builder.append(parser.fromHtml(Format.clearFormatting(textToPaste.toString()), context).trim())
-                Selection.setSelection(text, max)
+                Selection.setSelection(editable, max)
 
                 disableTextChangedListener()
-                text.replace(min, max, builder)
+                editable.replace(min, max, builder)
                 enableTextChangedListener()
 
-                joinStyleSpans(0, text.length) //TODO: see how this affects performance
+                joinStyleSpans(0, editable.length) //TODO: see how this affects performance
             }
         }
     }


### PR DESCRIPTION
Changed the copy-functionality to custom one. Default android one only supports standard style spans, which strips attributes and customs span data along the way.

With new one, we are still using system clipboard, but instead of passing Spanned string, we are converting it to html, and then back to Spanned before inserting into EditText.
For now this only works with AztecStyleSpan, and later we can add support for block elements (It kinda works, but sometimes rises exceptions, so I'm stripping all the Block spans for now).