### PR TITLE
Add Cursor Check to Avoid Index Out of Bounds Exception

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -40,7 +40,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
             historyCursor--
         }
 
-        while (historyCursor != historyList.size) {
+        while (historyCursor != historyList.size && historyCursor >= 0) {
             historyList.removeAt(historyCursor)
         }
 


### PR DESCRIPTION
### Fix
Add check to ensure cursor is positive integer before removing character at cursor position from list.  The cursor was decrementing to -1 and causing an `IndexOutOfBoundsException` crash as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/101.

### Test
1. Edit text exceeding history limit (demo app is 10).
2. Tap Undo repeatedly until history limit is reached.
3. Type any character.