### PR TITLE
Broken hidden HTML parsing

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -68,7 +68,11 @@ class AztecParser {
             hiddenSpans[hiddenIndex++] = it.endOrder
 
             // make sure every hidden span is attached to a character
-            data.insert(data.getSpanStart(it), "" + '\uFEFF')
+            val start = data.getSpanStart(it)
+            val end = data.getSpanEnd(it)
+            if (start == end && data[start] == '\n') {
+                data.insert(start, "" + '\uFEFF')
+            }
         }
         hiddenIndex = 0
         Arrays.sort(hiddenSpans)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -59,13 +59,16 @@ class AztecParser {
         // add a marker to the end of the text to aid nested group parsing
         val data = SpannableStringBuilder(cleanedUpText).append('\u200B')
 
-        resetHiddenTagParser(cleanedUpText)
+        resetHiddenTagParser(data)
 
-        val hidden = cleanedUpText.getSpans(0, cleanedUpText.length, HiddenHtmlSpan::class.java)
+        val hidden = data.getSpans(0, data.length, HiddenHtmlSpan::class.java)
         hiddenSpans = IntArray(hidden.size * 2)
         hidden.forEach {
             hiddenSpans[hiddenIndex++] = it.startOrder
             hiddenSpans[hiddenIndex++] = it.endOrder
+
+            // make sure every hidden span is attached to a character
+            data.insert(data.getSpanStart(it), "" + '\uFEFF')
         }
         hiddenIndex = 0
         Arrays.sort(hiddenSpans)
@@ -443,5 +446,6 @@ class AztecParser {
         return html
                 .replace("&#8203;", "")
                 .replace("(<br>)*</blockquote>".toRegex(), "</blockquote>")
+                .replace("&#65279;", "")
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1555,7 +1555,7 @@ class AztecText : EditText, TextWatcher {
     fun fromHtml(source: String) {
         val builder = SpannableStringBuilder()
         val parser = AztecParser()
-        builder.append(parser.fromHtml(Format.clearFormatting(source), context))
+        builder.append(parser.fromHtml(Format.clearFormatting(source), context).trim())
         switchToAztecStyle(builder, 0, builder.length)
         disableTextChangedListener()
         text = builder
@@ -1697,7 +1697,7 @@ class AztecText : EditText, TextWatcher {
                 val textToPaste = clip.getItemAt(i).coerceToText(context)
 
                 val builder = SpannableStringBuilder()
-                builder.append(parser.fromHtml(Format.clearFormatting(textToPaste.toString()), context))
+                builder.append(parser.fromHtml(Format.clearFormatting(textToPaste.toString()), context).trim())
                 Selection.setSelection(editable, max)
 
                 disableTextChangedListener()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1555,7 +1555,7 @@ class AztecText : EditText, TextWatcher {
     fun fromHtml(source: String) {
         val builder = SpannableStringBuilder()
         val parser = AztecParser()
-        builder.append(parser.fromHtml(Format.clearFormatting(source), context).trim())
+        builder.append(parser.fromHtml(Format.clearFormatting(source), context))
         switchToAztecStyle(builder, 0, builder.length)
         disableTextChangedListener()
         text = builder
@@ -1697,7 +1697,7 @@ class AztecText : EditText, TextWatcher {
                 val textToPaste = clip.getItemAt(i).coerceToText(context)
 
                 val builder = SpannableStringBuilder()
-                builder.append(parser.fromHtml(Format.clearFormatting(textToPaste.toString()), context).trim())
+                builder.append(parser.fromHtml(Format.clearFormatting(textToPaste.toString()), context))
                 Selection.setSelection(editable, max)
 
                 disableTextChangedListener()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -16,7 +16,7 @@ object Format {
         val newlineToTheRight = replaceAll(newlineToTheLeft, "<(/?(?!$block).)>\n(?!</?($block)>)", "<$1>")
         val fixBrNewlines = replaceAll(newlineToTheRight, "(<br>)(?!\n)", "$1\n")
 
-        return fixBrNewlines
+        return fixBrNewlines.trim()
     }
 
     fun clearFormatting(html: String): String {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -59,6 +59,8 @@ class AztecParserTest : AndroidTestCase() {
             "<div><div><div><span></span><div></div><span></span></div></div></div><br>" +
                     "<div><span>1</span><br><div>2</div>3<span></span><br>4</div><br><br>5<br><br><div></div>"
 
+    private val HTML_HIDDEN_WITH_NO_TEXT = "<br><br><div></div><br><br>"
+
     private val SPAN_BOLD = "Bold\n\n"
     private val SPAN_BULLET = "Bullet\n\n"
     private val SPAN_COMMENT = "Comment\n\n"
@@ -525,6 +527,22 @@ class AztecParserTest : AndroidTestCase() {
     fun parseHtmlToSpanToHtmlNestedInterleaving_isEqual() {
         val input =
                 HTML_NESTED_INTERLEAVING
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
+
+    /**
+     * Parse hidden HTML with no text from HTML to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHiddenHtmlWithNoTextToSpanToHtmlNestedInterleaving_isEqual() {
+        val input =
+                HTML_HIDDEN_WITH_NO_TEXT
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)


### PR DESCRIPTION
Fixes #82. The problem was that when a hidden html span wasn't attached to any non-whitespace character (such as `<br><div /><br>`), the parser would skip it and break the parsing of the other hidden spans.
