### PR TITLE
Continue Styling Text with Header Style Applied

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -505,7 +505,7 @@ class AztecText : EditText, TextWatcher {
         val lines = TextUtils.split(editableText.toString(), "\n")
 
         for (i in lines.indices) {
-            if (!containHeading(i)) {
+            if (!containsHeading(i)) {
                 continue
             }
 
@@ -594,7 +594,7 @@ class AztecText : EditText, TextWatcher {
         refreshText()
     }
 
-    private fun containHeading(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
+    private fun containsHeading(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
         val lines = TextUtils.split(editableText.toString(), "\n")
         val list = ArrayList<Int>()
 
@@ -627,7 +627,7 @@ class AztecText : EditText, TextWatcher {
         return true
     }
 
-    private fun containHeading(index: Int): Boolean {
+    private fun containsHeading(index: Int): Boolean {
         val lines = TextUtils.split(editableText.toString(), "\n")
 
         if (index < 0 || index >= lines.size) {
@@ -1293,7 +1293,7 @@ class AztecText : EditText, TextWatcher {
             TextFormat.FORMAT_HEADING_3,
             TextFormat.FORMAT_HEADING_4,
             TextFormat.FORMAT_HEADING_5,
-            TextFormat.FORMAT_HEADING_6 -> return containHeading(format, selStart, selEnd)
+            TextFormat.FORMAT_HEADING_6 -> return containsHeading(format, selStart, selEnd)
             TextFormat.FORMAT_BOLD -> return containsInlineStyle(TextFormat.FORMAT_BOLD, selStart, selEnd)
             TextFormat.FORMAT_ITALIC -> return containsInlineStyle(TextFormat.FORMAT_ITALIC, selStart, selEnd)
             TextFormat.FORMAT_UNDERLINED -> return containsInlineStyle(TextFormat.FORMAT_UNDERLINED, selStart, selEnd)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -447,6 +447,12 @@ class AztecText : EditText, TextWatcher {
 
     fun makeInlineSpan(textFormat: TextFormat): AztecInlineSpan {
         when (textFormat) {
+            TextFormat.FORMAT_HEADING_1 -> return AztecHeadingSpan(Heading.H1)
+            TextFormat.FORMAT_HEADING_2 -> return AztecHeadingSpan(Heading.H2)
+            TextFormat.FORMAT_HEADING_3 -> return AztecHeadingSpan(Heading.H3)
+            TextFormat.FORMAT_HEADING_4 -> return AztecHeadingSpan(Heading.H4)
+            TextFormat.FORMAT_HEADING_5 -> return AztecHeadingSpan(Heading.H5)
+            TextFormat.FORMAT_HEADING_6 -> return AztecHeadingSpan(Heading.H6)
             TextFormat.FORMAT_BOLD -> return AztecStyleSpan(Typeface.BOLD)
             TextFormat.FORMAT_ITALIC -> return AztecStyleSpan(Typeface.ITALIC)
             TextFormat.FORMAT_STRIKETHROUGH -> return AztecStrikethroughSpan()
@@ -1378,14 +1384,16 @@ class AztecText : EditText, TextWatcher {
         if (formattingIsApplied()) {
             for (item in selectedStyles) {
                 when (item) {
-                    TextFormat.FORMAT_BOLD -> if (!contains(item, textChangedEvent.inputStart, textChangedEvent.inputStart)) {
-                        applyInlineStyle(TextFormat.FORMAT_BOLD, textChangedEvent.inputStart, textChangedEvent.inputEnd)
-                    }
-                    TextFormat.FORMAT_ITALIC -> if (!contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
-                        applyInlineStyle(TextFormat.FORMAT_ITALIC, textChangedEvent.inputStart, textChangedEvent.inputEnd)
-                    }
-                    TextFormat.FORMAT_STRIKETHROUGH -> if (!contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
-                        applyInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, textChangedEvent.inputStart, textChangedEvent.inputEnd)
+                    TextFormat.FORMAT_HEADING_1,
+                    TextFormat.FORMAT_HEADING_2,
+                    TextFormat.FORMAT_HEADING_3,
+                    TextFormat.FORMAT_HEADING_4,
+                    TextFormat.FORMAT_HEADING_5,
+                    TextFormat.FORMAT_HEADING_6,
+                    TextFormat.FORMAT_BOLD,
+                    TextFormat.FORMAT_ITALIC,
+                    TextFormat.FORMAT_STRIKETHROUGH -> if (contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
+                        applyInlineStyle(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)
                     }
                     else -> {
                         //do nothing

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1389,10 +1389,12 @@ class AztecText : EditText, TextWatcher {
                     TextFormat.FORMAT_HEADING_3,
                     TextFormat.FORMAT_HEADING_4,
                     TextFormat.FORMAT_HEADING_5,
-                    TextFormat.FORMAT_HEADING_6,
+                    TextFormat.FORMAT_HEADING_6 -> if (contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
+                        applyInlineStyle(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)
+                    }
                     TextFormat.FORMAT_BOLD,
                     TextFormat.FORMAT_ITALIC,
-                    TextFormat.FORMAT_STRIKETHROUGH -> if (contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
+                    TextFormat.FORMAT_STRIKETHROUGH -> if (!contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
                         applyInlineStyle(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)
                     }
                     else -> {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1252,6 +1252,12 @@ class AztecText : EditText, TextWatcher {
         getAppliedStyles(start, end).forEach {
             if (!selectedStyles.contains(it) || ignoreSelectedStyles) {
                 when (it) {
+                    TextFormat.FORMAT_HEADING_1,
+                    TextFormat.FORMAT_HEADING_2,
+                    TextFormat.FORMAT_HEADING_3,
+                    TextFormat.FORMAT_HEADING_4,
+                    TextFormat.FORMAT_HEADING_5,
+                    TextFormat.FORMAT_HEADING_6 -> return removeInlineStyle(it, start, end)
                     TextFormat.FORMAT_BOLD -> removeInlineStyle(it, start, end)
                     TextFormat.FORMAT_ITALIC -> removeInlineStyle(it, start, end)
                     TextFormat.FORMAT_STRIKETHROUGH -> removeInlineStyle(it, start, end)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -4,7 +4,7 @@ import android.text.TextPaint
 import android.text.TextUtils
 import android.text.style.MetricAffectingSpan
 
-class AztecHeadingSpan @JvmOverloads constructor(val heading: Heading, attrs: String? = null) : MetricAffectingSpan(), AztecContentSpan {
+class AztecHeadingSpan @JvmOverloads constructor(val heading: Heading, attrs: String? = null) : MetricAffectingSpan(), AztecContentSpan, AztecInlineSpan {
 
     override var attributes: String? = attrs
 


### PR DESCRIPTION
### Fix

Continue styling when adding text to end of line with heading style as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/74.
### Test
1. Select line with heading style.
2. Enter new text.
3. Notice heading style continued.
4. Enter new line.
5. Enter new text.
6. Notice heading style not continued.
### Review

@khaykov
