### PR TITLE
Attribute unit tests

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -532,9 +532,6 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
             start(mSpannableStringBuilder, new Super(attributes));
         } else if (tag.equalsIgnoreCase("sub")) {
             start(mSpannableStringBuilder, new Sub(attributes));
-        } else if (tag.equalsIgnoreCase("p")) {
-            handleP(mSpannableStringBuilder);
-            start(mSpannableStringBuilder, new Paragraph(attributes));
         } else if (tag.length() == 2 &&
                 Character.toLowerCase(tag.charAt(0)) == 'h' &&
                 tag.charAt(1) >= '1' && tag.charAt(1) <= '6') {
@@ -606,32 +603,12 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
             end(mSpannableStringBuilder, TextFormat.FORMAT_SUPERSCRIPT);
         } else if (tag.equalsIgnoreCase("sub")) {
             end(mSpannableStringBuilder, TextFormat.FORMAT_SUBSCRIPT);
-        } else if (tag.equalsIgnoreCase("p")) {
-            handleP(mSpannableStringBuilder);
-            end(mSpannableStringBuilder, TextFormat.FORMAT_PARAGRAPH);
         } else if (tag.length() == 2 &&
                 Character.toLowerCase(tag.charAt(0)) == 'h' &&
                 tag.charAt(1) >= '1' && tag.charAt(1) <= '6') {
             endHeader(mSpannableStringBuilder);
         } else if (mTagHandler != null) {
             mTagHandler.handleTag(false, tag, mSpannableStringBuilder, mReader, null);
-        }
-    }
-
-    private static void handleP(SpannableStringBuilder text) {
-        int len = text.length();
-
-        if (len >= 1 && text.charAt(len - 1) == '\n') {
-            if (len >= 2 && text.charAt(len - 2) == '\n') {
-                return;
-            }
-
-            text.append("\n");
-            return;
-        }
-
-        if (len != 0) {
-            text.append("\n\n");
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -155,8 +155,7 @@ class AztecParser {
                 } else if (styles[0] is UnknownHtmlSpan) {
                     withinUnknown(styles[0] as UnknownHtmlSpan, out)
                 } else if (styles[0] is ParagraphSpan) {
-                    withinParagraph(out, text, i, next++)
-                    next++
+                    withinParagraph(out, text, i, next)
                 } else {
                     withinContent(out, text, i, next)
                 }
@@ -449,7 +448,8 @@ class AztecParser {
     private fun tidy(html: String): String {
         return html
                 .replace("&#8203;", "")
-                .replace("(<br>)*</blockquote>".toRegex(), "</blockquote>")
                 .replace("&#65279;", "")
+                .replace("(<br>)*</blockquote>".toRegex(), "</blockquote>")
+                .replace("(<br>)*</p>".toRegex(), "</p>")
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -75,7 +75,10 @@ class AztecTagHandler : Html.TagHandler {
                 handleBlockElement(output, opening, AztecQuoteSpan(attributeString))
                 return true
             }
-
+            PARAGRAPH -> {
+                handleBlockElement(output, opening, ParagraphSpan(attributeString))
+                return true
+            }
 
         }
         return false
@@ -163,6 +166,7 @@ class AztecTagHandler : Html.TagHandler {
         private val DIV = "div"
         private val SPAN = "span"
         private val BLOCKQUOTE = "blockquote"
+        private val PARAGRAPH = "p"
 
         private fun getLast(text: Editable, kind: Class<*>): Any? {
             val spans = text.getSpans(0, text.length, kind)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -431,17 +431,17 @@ class AztecText : EditText, TextWatcher {
             TextFormat.FORMAT_ORDERED_LIST -> return AztecOrderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
             TextFormat.FORMAT_UNORDERED_LIST -> return AztecUnorderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
             TextFormat.FORMAT_QUOTE -> return AztecQuoteSpan(quoteBackground, quoteColor, quoteMargin, quoteWidth, quotePadding, attrs)
-            else -> return AztecOrderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding)
+            else -> return ParagraphSpan(attrs)
         }
     }
 
 
-    fun makeBlockSpan(spanType: Class<AztecBlockSpan>, attrs: String? = null): LeadingMarginSpan {
+    fun makeBlockSpan(spanType: Class<AztecBlockSpan>, attrs: String? = null): AztecBlockSpan {
         when (spanType) {
             AztecOrderedListSpan::class.java -> return AztecOrderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
             AztecUnorderedListSpan::class.java -> return AztecUnorderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
             AztecQuoteSpan::class.java -> return AztecQuoteSpan(quoteBackground, quoteColor, quoteMargin, quoteWidth, quotePadding, attrs)
-            else -> return AztecOrderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding)
+            else -> return ParagraphSpan(attrs)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -6,7 +6,7 @@ import java.util.regex.Pattern
 object Format {
 
     // list of block elements
-    private val block = "div|span|br|blockquote|ul|ol|li|h1|h2|h3|h4|h5|h6"
+    private val block = "div|span|br|blockquote|ul|ol|li|h1|h2|h3|h4|h5|h6|p"
 
     fun addFormatting(content: String): String {
         val doc = Jsoup.parseBodyFragment(content)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/ParagraphSpan.kt
@@ -3,7 +3,7 @@ package org.wordpress.aztec.spans
 import android.text.TextUtils
 import android.text.style.ParagraphStyle
 
-class ParagraphSpan : ParagraphStyle, AztecContentSpan {
+class ParagraphSpan : ParagraphStyle, AztecBlockSpan {
 
     private final var TAG: String = "p"
     override var attributes: String?

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -1,0 +1,280 @@
+package org.wordpress.aztec
+
+import android.app.Activity
+import android.text.SpannableString
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricGradleTestRunner
+import org.robolectric.annotation.Config
+import org.wordpress.aztec.source.Format
+
+/**
+ * Testing attribute preservation for supported HTML elements
+ */
+@RunWith(RobolectricGradleTestRunner::class)
+@Config(constants = BuildConfig::class)
+class AttributeTest {
+
+    companion object {
+        private val HEADING =
+                "<h1 a=\"A\">Heading 1</h1><br>" +
+                "<h2 b=\"B\">Heading 2</h2><br>" +
+                "<h3 c=\"C\">Heading 3</h3><br>" +
+                "<h4 d=\"D\">Heading 4</h4><br>" +
+                "<h5 e=\"E\">Heading 5</h5><br>" +
+                "<h6 f=\"F\">Heading 6</h6>"
+        private val BOLD = "<b h=\"H\">Bold</b>"
+        private val BOLD_NO_ATTRS = "<b>Bold</b>"
+        private val ITALIC = "<i i=\"I\">Italic</i>"
+        private val UNDERLINE = "<u j=\"J\">Underline</u>"
+        private val NESTED = "<i a=\"A\"><b><u class=\"klass\">Nested</u></b><i>"
+        private val NESTED_REVERSED = "<u class=\"klass\"><b><i a=\"A\">Nested</i></b></u>"
+        private val STRIKETHROUGH = "<s class=\"test\">Strikethrough</s>" // <s> or <strike> or <del>
+        private val ORDERED = "<ol l=\"L\"><li>Ordered</li></ol>"
+        private val UNORDERED = "<ul m=\"M\"><li>Unordered</li></ul>"
+        private val QUOTE = "<blockquote n=\"N\">Quote</blockquote>"
+        private val LINK = "<a o=\"O\" href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a>"
+        private val UNKNOWN = "<iframe class=\"classic\" p=\"P\">Menu</iframe>"
+        private val COMMENT = "<!--Comment--><br>"
+        private val COMMENT_MORE = "<!--more--><br>"
+        private val COMMENT_PAGE = "<!--nextpage--><br>"
+        private val LIST = "<ol><li a=\"1\">Ordered</li></ol>"
+        private val SUB = "<sub i=\"I\">Sub</sub>"
+        private val SUP = "<sup i=\"I\">Sup</sup>"
+        private val FONT = "<font i=\"I\">Font</font>"
+        private val TT = "<tt t=\"T\">Monospace</tt>"
+        private val BIG = "<big b=\"B\">Big</big>"
+        private val SMALL = "<small s=\"S\">Small</small>"
+        private val P = "<p p=\"P\">Paragraph</p>" + BOLD_NO_ATTRS
+        private val MIXED = HEADING + BOLD + ITALIC + UNDERLINE + STRIKETHROUGH + ORDERED +
+                UNORDERED + QUOTE + LINK + COMMENT + COMMENT_MORE + COMMENT_PAGE +
+                UNKNOWN + LIST + SUB + SUP + FONT + TT + BIG + SMALL + P
+    }
+
+    lateinit var editText: AztecText
+
+    /**
+     * Initialize variables.
+     */
+    @Before
+    fun init() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().visible().get()
+        editText = AztecText(activity)
+        activity.setContentView(editText)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun headingAttributes() {
+        val input = HEADING
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun italicAttributes() {
+        val input = ITALIC
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun boldAttributes() {
+        val input = BOLD
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun boldWithoutAttributes() {
+        val input = BOLD_NO_ATTRS
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun nestedAttributes() {
+        val input = NESTED
+        val expected = NESTED_REVERSED
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(expected, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun underlineAttributes() {
+        val input = UNDERLINE
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun strikethroughAttributes() {
+        val input = STRIKETHROUGH
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun orderedAttributes() {
+        val input = ORDERED
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+    @Test
+    @Throws(Exception::class)
+    fun unorderedAttributes() {
+        val input = UNORDERED
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun quoteAttributes() {
+        val input = QUOTE
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun linkAttributes() {
+        val input = LINK
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun unknownAttributes() {
+        val input = UNKNOWN
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun listAttributes() {
+        val input = LIST
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun subAttributes() {
+        val input = SUB
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun supAttributes() {
+        val input = SUP
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun fontAttributes() {
+        val input = FONT
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun typefaceAttributes() {
+        val input = TT
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun bigAttributes() {
+        val input = BIG
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun smallAttributes() {
+        val input = SMALL
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun paragraphAttributes() {
+        val input = P
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(input, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun mixedAttributes() {
+        val input = MIXED + NESTED
+        val expected = MIXED + NESTED_REVERSED
+        editText.fromHtml(input)
+        val output = editText.toHtml()
+        Assert.assertEquals(expected, output)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun mixedInlineAndBlockElementsWithoutExtraSpacing() {
+        editText.append("some text")
+        editText.append("\n")
+        editText.append("quote")
+        editText.setSelection(editText.length())
+        editText.toggleFormatting(TextFormat.FORMAT_QUOTE)
+        Assert.assertEquals("some text<blockquote>quote</blockquote>", editText.toHtml())
+        editText.setSelection(editText.length())
+        editText.append("\n")
+        editText.append("\n")
+        editText.append("list")
+        editText.setSelection(editText.length())
+        editText.toggleFormatting(TextFormat.FORMAT_UNORDERED_LIST)
+        editText.append("\n")
+        editText.append("\n")
+        editText.append("some text")
+
+        Assert.assertEquals("some text<blockquote>quote</blockquote><ul><li>list</li></ul>some text", editText.toHtml())
+    }
+}

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -1,7 +1,7 @@
 package org.wordpress.aztec
 
 import android.app.Activity
-import android.text.SpannableString
+import android.widget.ToggleButton
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -9,7 +9,8 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricGradleTestRunner
 import org.robolectric.annotation.Config
-import org.wordpress.aztec.source.Format
+import org.wordpress.aztec.source.SourceViewEditText
+import org.wordpress.aztec.toolbar.AztecToolbar
 
 /**
  * Testing attribute preservation for supported HTML elements
@@ -42,6 +43,7 @@ class AttributeTest {
         private val COMMENT_MORE = "<!--more--><br>"
         private val COMMENT_PAGE = "<!--nextpage--><br>"
         private val LIST = "<ol><li a=\"1\">Ordered</li></ol>"
+        private val LIST_WITH_EMPTY_ITEMS = "<ul><li></li><li a=\"1\">1</li><li></li></ul>"
         private val SUB = "<sub i=\"I\">Sub</sub>"
         private val SUP = "<sup i=\"I\">Sup</sup>"
         private val FONT = "<font i=\"I\">Font</font>"
@@ -256,25 +258,34 @@ class AttributeTest {
         Assert.assertEquals(expected, output)
     }
 
+    //TODO: After fixing list item attribute preservation, uncomment this
+//    @Test
+//    @Throws(Exception::class)
+//    fun listWithEmptyItemsAttributes() {
+//        val input = LIST_WITH_EMPTY_ITEMS
+//        val output = editText.fromHtml(input)
+//        Assert.assertEquals(input, output)
+//    }
+
     @Test
     @Throws(Exception::class)
-    fun mixedInlineAndBlockElementsWithoutExtraSpacing() {
-        editText.append("some text")
+    fun appendItemToList() {
+        val input = LIST
+        val originalItem = "<li a=\"1\">Ordered</li>"
+        editText.fromHtml(input)
         editText.append("\n")
-        editText.append("quote")
-        editText.setSelection(editText.length())
-        editText.toggleFormatting(TextFormat.FORMAT_QUOTE)
-        Assert.assertEquals("some text<blockquote>quote</blockquote>", editText.toHtml())
-        editText.setSelection(editText.length())
-        editText.append("\n")
-        editText.append("\n")
-        editText.append("list")
-        editText.setSelection(editText.length())
-        editText.toggleFormatting(TextFormat.FORMAT_UNORDERED_LIST)
-        editText.append("\n")
-        editText.append("\n")
-        editText.append("some text")
+        editText.append("after")
+        Assert.assertEquals("<ol>$originalItem<li>after</li></ol>", editText.toHtml())
+    }
 
-        Assert.assertEquals("some text<blockquote>quote</blockquote><ul><li>list</li></ul>some text", editText.toHtml())
+    @Test
+    @Throws(Exception::class)
+    fun prependItemToList() {
+        val input = LIST
+        val originalItem = "<li a=\"1\">Ordered</li>"
+        editText.fromHtml(input)
+        editText.setSelection(0)
+        editText.text.insert(0, "before\n")
+        Assert.assertEquals("<ol><li>before</li>$originalItem</ol>", editText.toHtml())
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -48,7 +48,7 @@ class AttributeTest {
         private val TT = "<tt t=\"T\">Monospace</tt>"
         private val BIG = "<big b=\"B\">Big</big>"
         private val SMALL = "<small s=\"S\">Small</small>"
-        private val P = "<p p=\"P\">Paragraph</p>" + BOLD_NO_ATTRS
+        private val P = "<p p=\"P\">Paragraph</p>"
         private val MIXED = HEADING + BOLD + ITALIC + UNDERLINE + STRIKETHROUGH + ORDERED +
                 UNORDERED + QUOTE + LINK + COMMENT + COMMENT_MORE + COMMENT_PAGE +
                 UNKNOWN + LIST + SUB + SUP + FONT + TT + BIG + SMALL + P


### PR DESCRIPTION
Addresses #95.

Moved the `<p>` parsing to `AztecTagHandler` and used the existing `AztecBlockSpan` parsing logic for it.

There is one test that's commented out because list item attribute preservation is not working yet.