### PR TITLE
Issue/69 retain cursor position between editor modes

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -38,6 +38,7 @@ import org.ccil.cowan.tagsoup.Parser;
 import org.wordpress.aztec.spans.AztecBlockSpan;
 import org.wordpress.aztec.spans.AztecCommentSpan;
 import org.wordpress.aztec.spans.AztecContentSpan;
+import org.wordpress.aztec.spans.AztecCursorSpan;
 import org.wordpress.aztec.spans.AztecHeadingSpan;
 import org.wordpress.aztec.spans.AztecListSpan;
 import org.wordpress.aztec.spans.AztecRelativeSizeSpan;
@@ -504,6 +505,8 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         if (tag.equalsIgnoreCase("br")) {
             // We don't need to handle this. TagSoup will ensure that there's a </br> for each <br>
             // so we can safely emite the linebreaks when we handle the close tag.
+        } else if (tag.equalsIgnoreCase("aztec_cursor")) {
+            start(mSpannableStringBuilder, new AztecCursorSpan());
         } else if (tag.equalsIgnoreCase("strong")) {
             start(mSpannableStringBuilder, new Bold(attributes));
         } else if (tag.equalsIgnoreCase("b")) {
@@ -609,12 +612,25 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         } else if (tag.equalsIgnoreCase("p")) {
             handleP(mSpannableStringBuilder);
             end(mSpannableStringBuilder, TextFormat.FORMAT_PARAGRAPH);
+        } else if (tag.equalsIgnoreCase("aztec_cursor")) {
+            endCursor(mSpannableStringBuilder);
         } else if (tag.length() == 2 &&
                 Character.toLowerCase(tag.charAt(0)) == 'h' &&
                 tag.charAt(1) >= '1' && tag.charAt(1) <= '6') {
             endHeader(mSpannableStringBuilder);
         } else if (mTagHandler != null) {
             mTagHandler.handleTag(false, tag, mSpannableStringBuilder, mReader, null);
+        }
+    }
+
+    private static void endCursor(SpannableStringBuilder text) {
+        Object last = getLast(text, AztecCursorSpan.class);
+        int start = text.getSpanStart(last);
+        int end = text.length();
+
+        text.removeSpan(last);
+        if (start == end) {
+            text.setSpan(last, start, end, Spanned.SPAN_MARK_MARK);
         }
     }
 

--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -606,9 +606,6 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
             end(mSpannableStringBuilder, TextFormat.FORMAT_SUPERSCRIPT);
         } else if (tag.equalsIgnoreCase("sub")) {
             end(mSpannableStringBuilder, TextFormat.FORMAT_SUBSCRIPT);
-        } else if (tag.equalsIgnoreCase("p")) {
-            handleP(mSpannableStringBuilder);
-            end(mSpannableStringBuilder, TextFormat.FORMAT_PARAGRAPH);
         } else if (tag.equalsIgnoreCase("aztec_cursor")) {
             endCursor(mSpannableStringBuilder);
         } else if (tag.length() == 2 &&
@@ -628,23 +625,6 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         text.removeSpan(last);
         if (start == end) {
             text.setSpan(last, start, end, Spanned.SPAN_MARK_MARK);
-        }
-    }
-
-    private static void handleP(SpannableStringBuilder text) {
-        int len = text.length();
-
-        if (len >= 1 && text.charAt(len - 1) == '\n') {
-            if (len >= 2 && text.charAt(len - 2) == '\n') {
-                return;
-            }
-
-            text.append("\n");
-            return;
-        }
-
-        if (len != 0) {
-            text.append("\n\n");
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -244,8 +244,6 @@ class AztecParser {
             }
 
             withinContent(out, text.subSequence(newStart..newEnd) as Spanned, lineStart, lineEnd)
-
-
             out.append("</li>")
         }
         out.append("</${list.getEndTag()}>")
@@ -328,12 +326,11 @@ class AztecParser {
 
         run {
             var i = start
-            var localCursorPosition: Int  //cursor position relevant to the part of text we are parsing
 
             while (i < end || start == end) {
                 next = text.nextSpanTransition(i, end, CharacterStyle::class.java)
 
-                localCursorPosition = getLocalCursorPosition(text, if (i > 0) i - 1 else 0, next)
+               val localCursorPosition = getLocalCursorPosition(text, if (i > 0) i - 1 else 0, next)
 
                 val spans = text.getSpans(i, next, CharacterStyle::class.java)
                 for (j in spans.indices) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -1556,9 +1556,11 @@ class AztecText : EditText, TextWatcher {
         val output = SpannableStringBuilder(text)
         BaseInputConnection.removeComposingSpans(output)
 
-        val html = if (withCursorTag) parser.toHtmlWithCursorTag(output, selectionEnd) else parser.toHtml(output)
+        if (withCursorTag && selectionEnd > 0) {
+            output.setSpan(AztecCursorSpan(), selectionEnd, selectionEnd, Spanned.SPAN_MARK_MARK)
+        }
 
-        return Format.clearFormatting(html)
+        return Format.clearFormatting(parser.toHtml(output, withCursorTag))
     }
 
     fun toFormattedHtml(): String {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
@@ -51,13 +51,10 @@ data class TextChangedEvent(val text: CharSequence, val start: Int, val before: 
         if (count >= 0) {
 
             if (text.length > inputStart)  {
-                val spans = editableText.getSpans(start, start, AztecBlockSpan::class.java)
+                val spans = editableText.getSpans(inputStart, inputStart, AztecBlockSpan::class.java)
 
                 spans.forEach {
-
-                    if((isAddingCharacters && inputStart == 0) || (!isAddingCharacters && inputEnd == 0)) return@forEach
-
-                    val previousCharacter = if (isAddingCharacters) text[inputStart - 1] else text[inputEnd - 1]
+                    val previousCharacter = if (isAddingCharacters) text[inputStart - 1] else text[inputEnd]
 
                     if (previousCharacter == '\n') return@forEach
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
@@ -49,13 +49,11 @@ data class TextChangedEvent(val text: CharSequence, val start: Int, val before: 
 
         val spansToClose = ArrayList<AztecBlockSpan>()
         if (count >= 0) {
-
             if (text.length > inputStart)  {
                 val spans = editableText.getSpans(inputStart, inputStart, AztecBlockSpan::class.java)
 
                 spans.forEach {
                     val previousCharacter = if (isAddingCharacters) text[inputStart - 1] else text[inputEnd]
-
                     if (previousCharacter == '\n') return@forEach
 
                     val deletingLastCharacter = !isAddingCharacters && text.length == inputEnd

--- a/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
@@ -45,10 +45,12 @@ data class TextChangedEvent(val text: CharSequence, val start: Int, val before: 
 
         val spansToClose = ArrayList<AztecBlockSpan>()
         if (count >= 0) {
-            if (text.length > inputStart) {
+            if (text.length > inputStart)  {
                 val spans = editableText.getSpans(start, start, AztecBlockSpan::class.java)
 
                 spans.forEach {
+
+                    if((isAddingCharacters && inputStart == 0) || (!isAddingCharacters && inputEnd == 0)) return@forEach
 
                     val previousCharacter = if (isAddingCharacters) text[inputStart - 1] else text[inputEnd - 1]
                     if (previousCharacter == '\n') return@forEach

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -1,7 +1,6 @@
 package org.wordpress.aztec.source
 
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
 import java.util.regex.Pattern
 
 object Format {
@@ -10,8 +9,7 @@ object Format {
     private val block = "h1|h2|h3|h4|h5|h6|div|span|br|blockquote|ul|ol|li"
 
     fun addFormatting(content: String): String {
-        val settings = Document.OutputSettings().prettyPrint(true).outline(true)
-        val doc = Jsoup.parseBodyFragment(content).outputSettings(settings)
+        val doc = Jsoup.parseBodyFragment(content)
 
         //remove newline around all non block elements
         val newlineToTheLeft = replaceAll(doc.body().html(), "(?<!</?$block>)\n<(/?(?!$block).)>", "<$1>")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -1,15 +1,17 @@
 package org.wordpress.aztec.source
 
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import java.util.regex.Pattern
 
 object Format {
 
     // list of block elements
-    private val block = "div|span|br|blockquote|ul|ol|li|h1|h2|h3|h4|h5|h6"
+    private val block = "h1|h2|h3|h4|h5|h6|div|span|br|blockquote|ul|ol|li"
 
     fun addFormatting(content: String): String {
-        val doc = Jsoup.parseBodyFragment(content)
+        val settings = Document.OutputSettings().prettyPrint(true).outline(true)
+        val doc = Jsoup.parseBodyFragment(content).outputSettings(settings)
 
         //remove newline around all non block elements
         val newlineToTheLeft = replaceAll(doc.body().html(), "(?<!</?$block>)\n<(/?(?!$block).)>", "<$1>")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -6,7 +6,7 @@ import java.util.regex.Pattern
 object Format {
 
     // list of block elements
-    private val block = "h1|h2|h3|h4|h5|h6|div|span|br|blockquote|ul|ol|li"
+    private val block = "div|span|br|blockquote|ul|ol|li|p|h1|h2|h3|h4|h5|h6"
 
     fun addFormatting(content: String): String {
         val doc = Jsoup.parseBodyFragment(content)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -12,9 +12,9 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.View
 import android.widget.EditText
-import org.wordpress.aztec.AztecParser
 import org.wordpress.aztec.History
 import org.wordpress.aztec.R
+import org.wordpress.aztec.spans.AztecCursorSpan
 import org.wordpress.aztec.util.TypefaceCache
 
 class SourceViewEditText : EditText, TextWatcher {
@@ -150,9 +150,9 @@ class SourceViewEditText : EditText, TextWatcher {
     }
 
     fun consumeCursorTag(styledHtml: SpannableStringBuilder): Int {
-        val cursorTagIndex = styledHtml.indexOf(AztecParser.AZTEC_CURSOR_TAG)
+        val cursorTagIndex = styledHtml.indexOf(AztecCursorSpan.AZTEC_CURSOR_TAG)
         if (cursorTagIndex < 0) return 0
-        styledHtml.delete(cursorTagIndex, cursorTagIndex + AztecParser.AZTEC_CURSOR_TAG.length)
+        styledHtml.delete(cursorTagIndex, cursorTagIndex + AztecCursorSpan.AZTEC_CURSOR_TAG.length)
         return cursorTagIndex
     }
 
@@ -170,13 +170,11 @@ class SourceViewEditText : EditText, TextWatcher {
     }
 
     fun isCursorInsideTag(): Boolean {
-
         val indexOfFirstClosingBracketOnTheRight = text.indexOf(">", selectionEnd)
         val indexOfFirstOpeningBracketOnTheRight = text.indexOf("<", selectionEnd)
 
         val isThereClosingBracketBeforeOpeningBracket = indexOfFirstClosingBracketOnTheRight != -1 &&
                 indexOfFirstClosingBracketOnTheRight < indexOfFirstOpeningBracketOnTheRight
-
 
         val indexOfFirstClosingBracketOnTheLeft = text.lastIndexOf(">", selectionEnd)
         val indexOfFirstOpeningBracketOnTheLeft = text.lastIndexOf("<", selectionEnd)
@@ -185,7 +183,6 @@ class SourceViewEditText : EditText, TextWatcher {
                 indexOfFirstOpeningBracketOnTheLeft > indexOfFirstClosingBracketOnTheLeft
 
         return isThereClosingBracketBeforeOpeningBracket && isThereOpeningBracketBeforeClosingBracket
-
     }
 
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
@@ -1,12 +1,8 @@
 package org.wordpress.aztec.spans
 
-import android.text.TextPaint
-import android.text.style.CharacterStyle
 
+class AztecCursorSpan  {
 
-class AztecCursorSpan : CharacterStyle() {
-    override fun updateDrawState(tp: TextPaint?) {
-    }
 
     val TAG = "aztec_cursor"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
@@ -3,6 +3,8 @@ package org.wordpress.aztec.spans
 
 class AztecCursorSpan  {
 
+    companion object {
+        val AZTEC_CURSOR_TAG = "aztec_cursor"
+    }
 
-    val TAG = "aztec_cursor"
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCursorSpan.kt
@@ -1,0 +1,12 @@
+package org.wordpress.aztec.spans
+
+import android.text.TextPaint
+import android.text.style.CharacterStyle
+
+
+class AztecCursorSpan : CharacterStyle() {
+    override fun updateDrawState(tp: TextPaint?) {
+    }
+
+    val TAG = "aztec_cursor"
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -212,14 +212,15 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
             ToolbarAction.PAGE -> editor!!.applyComment(AztecCommentSpan.Comment.PAGE)
             ToolbarAction.HTML -> {
                 if (editor!!.visibility == View.VISIBLE) {
-                    sourceEditor!!.displayStyledAndFormattedHtml(editor!!.toHtml())
+                    sourceEditor!!.displayStyledAndFormattedHtml(editor!!.toHtml(true))
 
                     editor!!.visibility = View.GONE
                     sourceEditor!!.visibility = View.VISIBLE
+                    sourceEditor!!.requestFocus()
 
                     toggleHtmlMode(true)
                 } else {
-                    editor!!.fromHtml(sourceEditor!!.getPureHtml())
+                    editor!!.fromHtml(sourceEditor!!.getPureHtml(true))
 
                     editor!!.visibility = View.VISIBLE
                     sourceEditor!!.visibility = View.GONE
@@ -260,7 +261,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                 toggleButtonState(findViewById(action.buttonId), !isHtmlMode)
             }
         }
-	}
+    }
 
     private fun showLinkDialog(presetUrl: String = "", presetAnchor: String = "") {
         if (!isEditorAttached()) return

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -216,7 +216,6 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
 
                     editor!!.visibility = View.GONE
                     sourceEditor!!.visibility = View.VISIBLE
-                    sourceEditor!!.requestFocus()
 
                     toggleHtmlMode(true)
                 } else {


### PR DESCRIPTION
This PR adds support for cursor synchronization between visual and source editors (#69).

This task turned out to be not as trivial as I expected - there is a huge difference between spanned text and "prettified" html, and placing cursor to be where it actually should be was quite tricky.

When we want to show cursor in source editor we are marking the end of selection with cursor span, and then in parser we insert "aztec_cursor" word where we think it should be. We don't use `<aztec_cursor></aztec_cursor>` tag because Jsoup tries to "prettify" it and everything becomes really complicated.

Moving cursor from source to visual editor was relatively easy, and we actually use the tag (`<aztec_cursor></aztec_cursor>`), parse it to span and then just consume it.


Tests will come a bit later.
