### PR TITLE
Feature/aztec refactoring

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aztec="http://schemas.android.com/apk/res-auto"
-    android:layout_height="match_parent"
-    android:layout_width="match_parent">
+                xmlns:aztec="http://schemas.android.com/apk/res-auto"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
     <org.wordpress.aztec.toolbar.AztecToolbar
         android:id="@+id/formatting_toolbar"
-        android:layout_alignParentBottom="true"
+        android:layout_width="match_parent"
         android:layout_height="@dimen/format_bar_height"
-        android:layout_width="match_parent" >
+        android:layout_alignParentBottom="true">
     </org.wordpress.aztec.toolbar.AztecToolbar>
 
     <ScrollView
-        android:layout_above="@+id/formatting_toolbar"
-        android:layout_alignParentTop="true"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_width="match_parent" >
+        android:layout_above="@+id/formatting_toolbar"
+        android:layout_alignParentTop="true">
 
         <FrameLayout
             android:layout_width="match_parent"
@@ -24,52 +24,35 @@
 
             <org.wordpress.aztec.AztecText
                 android:id="@+id/aztec"
-                android:hint="@string/edit_hint"
-                android:layout_height="wrap_content"
                 android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/edit_hint"
                 android:paddingEnd="16dp"
                 android:paddingLeft="16dp"
                 android:paddingRight="16dp"
                 android:paddingStart="16dp"
                 android:paddingTop="16dp"
                 android:scrollbars="vertical"
-                android:textCursorDrawable="?attr/textColor"
-                aztec:backgroundColor="@android:color/transparent"
-                aztec:bulletColor="@color/blue_medium"
-                aztec:bulletMargin="@dimen/bullet_margin"
-                aztec:bulletPadding="@dimen/bullet_padding"
-                aztec:bulletWidth="@dimen/bullet_width"
                 aztec:historyEnable="true"
-                aztec:historySize="10"
-                aztec:lineSpacingExtra="@dimen/spacing_extra"
-                aztec:lineSpacingMultiplier="@dimen/spacing_multiplier"
-                aztec:linkColor="@color/blue_wordpress"
-                aztec:linkUnderline="false"
-                aztec:quoteBackground="@color/blue_wordpress"
-                aztec:quoteColor="@color/blue_medium"
-                aztec:quoteMargin="@dimen/quote_margin"
-                aztec:quotePadding="@dimen/quote_padding"
-                aztec:quoteWidth="@dimen/quote_width"
-                aztec:textColor="@android:color/white"
-                aztec:textColorHint="@android:color/darker_gray" />
+                aztec:historySize="10"/>
 
             <org.wordpress.aztec.source.SourceViewEditText
                 android:id="@+id/source"
-                android:hint="@string/source_hint"
-                android:layout_height="wrap_content"
                 android:layout_width="match_parent"
-                android:paddingTop="16dp"
-                android:paddingLeft="16dp"
-                android:paddingStart="16dp"
-                android:paddingRight="16dp"
-                android:paddingEnd="16dp"
+                android:layout_height="wrap_content"
                 android:gravity="top|start"
+                android:hint="@string/source_hint"
+                android:inputType="textNoSuggestions|textMultiLine"
+                android:paddingEnd="16dp"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:paddingStart="16dp"
+                android:paddingTop="16dp"
                 android:scrollbars="vertical"
                 android:textSize="14sp"
                 android:visibility="gone"
-                android:inputType="textNoSuggestions|textMultiLine"
-                aztec:codeTextColor="@android:color/white"
-                aztec:codeBackgroundColor="@android:color/transparent" />
+                aztec:codeBackgroundColor="@android:color/transparent"
+                aztec:codeTextColor="@android:color/white"/>
 
         </FrameLayout>
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -250,7 +250,6 @@ class AztecText : EditText, TextWatcher {
         return editableText.substring(selectionStart, selectionEnd)
     }
 
-
     fun getAppliedStyles(selectionStart: Int, selectionEnd: Int): ArrayList<TextFormat> {
         val styles = ArrayList<TextFormat>()
         TextFormat.values().forEach {
@@ -277,7 +276,6 @@ class AztecText : EditText, TextWatcher {
         isNewStyleSelected = false
     }
 
-
     fun isTextSelected(): Boolean {
         return selectionStart != selectionEnd
     }
@@ -299,8 +297,8 @@ class AztecText : EditText, TextWatcher {
             TextFormat.FORMAT_UNORDERED_LIST -> blockFormatter.toggleUnorderedList()
             TextFormat.FORMAT_ORDERED_LIST -> blockFormatter.toggleOrderedList()
             TextFormat.FORMAT_QUOTE -> blockFormatter.toggleQuote()
-            TextFormat.FORMAT_MORE -> lineBlockFormatter.applyComment(AztecCommentSpan.Comment.MORE)
-            TextFormat.FORMAT_PAGE -> lineBlockFormatter.applyComment(AztecCommentSpan.Comment.PAGE)
+            TextFormat.FORMAT_MORE -> lineBlockFormatter.applyMoreComment()
+            TextFormat.FORMAT_PAGE -> lineBlockFormatter.applyPageComment()
             else -> {
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -20,62 +20,80 @@ package org.wordpress.aztec
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.graphics.Typeface
 import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import android.support.v4.content.ContextCompat
+import android.support.v7.app.AlertDialog
 import android.text.*
 import android.text.style.LeadingMarginSpan
 import android.text.style.ParagraphStyle
-import android.text.style.StyleSpan
 import android.text.style.SuggestionSpan
 import android.util.AttributeSet
-import android.util.Patterns
+import android.view.LayoutInflater
 import android.view.View
 import android.view.inputmethod.BaseInputConnection
-import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import org.wordpress.aztec.formatting.BlockFormatter
+import org.wordpress.aztec.formatting.InlineFormatter
+import org.wordpress.aztec.formatting.LineBlockFormatter
+import org.wordpress.aztec.formatting.LinkFormatter
 import org.wordpress.aztec.source.Format
 import org.wordpress.aztec.spans.*
-import org.wordpress.aztec.spans.AztecHeadingSpan.Heading
 import org.wordpress.aztec.util.TypefaceCache
 import java.util.*
 
 class AztecText : EditText, TextWatcher {
 
-    private var bulletColor = ContextCompat.getColor(context, R.color.bullet)
-    private var bulletMargin = resources.getDimensionPixelSize(R.dimen.bullet_margin)
-    private var bulletPadding = resources.getDimensionPixelSize(R.dimen.bullet_padding)
-    private var bulletWidth = resources.getDimensionPixelSize(R.dimen.bullet_width)
+    var bulletColor = ContextCompat.getColor(context, R.color.bullet)
+    var bulletMargin = resources.getDimensionPixelSize(R.dimen.bullet_margin)
+    var bulletPadding = resources.getDimensionPixelSize(R.dimen.bullet_padding)
+    var bulletWidth = resources.getDimensionPixelSize(R.dimen.bullet_width)
+
+    var linkColor = ContextCompat.getColor(context, R.color.link)
+    var linkUnderline = resources.getBoolean(R.bool.link_underline)
+
+    var quoteBackground = ContextCompat.getColor(context, R.color.quote_background)
+    var quoteColor = ContextCompat.getColor(context, R.color.quote)
+    var quoteMargin = resources.getDimensionPixelSize(R.dimen.quote_margin)
+    var quotePadding = resources.getDimensionPixelSize(R.dimen.quote_padding)
+    var quoteWidth = resources.getDimensionPixelSize(R.dimen.quote_width)
+
     private var historyEnable = resources.getBoolean(R.bool.history_enable)
     private var historySize = resources.getInteger(R.integer.history_size)
-    private var linkColor = ContextCompat.getColor(context, R.color.link)
-    private var linkUnderline = resources.getBoolean(R.bool.link_underline)
-    private var quoteBackground = ContextCompat.getColor(context, R.color.quote_background)
-    private var quoteColor = ContextCompat.getColor(context, R.color.quote)
-    private var quoteMargin = resources.getDimensionPixelSize(R.dimen.quote_margin)
-    private var quotePadding = resources.getDimensionPixelSize(R.dimen.quote_padding)
-    private var quoteWidth = resources.getDimensionPixelSize(R.dimen.quote_width)
 
+
+    private var addLinkDialog: AlertDialog? = null
     private var consumeEditEvent: Boolean = false
     private var textChangedEventDetails = TextChangedEvent("", 0, 0, 0)
 
     private var onSelectionChangedListener: OnSelectionChangedListener? = null
 
-    private val selectedStyles = ArrayList<TextFormat>()
+    private var isViewInitialized = false
+
+    val selectedStyles = ArrayList<TextFormat>()
 
     private var isNewStyleSelected = false
 
     lateinit var history: History
 
-    data class CarryOverSpan(val span: AztecInlineSpan, val start: Int, val end: Int)
 
-    val carryOverSpans = ArrayList<CarryOverSpan>()
+    val inlineFormatter: InlineFormatter
+    val blockFormatter: BlockFormatter
+    val lineBlockFormatter: LineBlockFormatter
+    val linkFormatter: LinkFormatter
 
     interface OnSelectionChangedListener {
         fun onSelectionChanged(selStart: Int, selEnd: Int)
     }
+
+    init {
+        inlineFormatter = InlineFormatter(this)
+        blockFormatter = BlockFormatter(this)
+        lineBlockFormatter = LineBlockFormatter(this)
+        linkFormatter = LinkFormatter(this)
+    }
+
 
     constructor(context: Context) : super(context) {
         init(null)
@@ -92,7 +110,7 @@ class AztecText : EditText, TextWatcher {
     private fun init(attrs: AttributeSet?) {
         TypefaceCache.setCustomTypeface(context, this, TypefaceCache.TYPEFACE_MERRIWEATHER_REGULAR)
 
-        val array = context.obtainStyledAttributes(attrs, R.styleable.AztecText)
+        val array = context.obtainStyledAttributes(attrs, R.styleable.AztecText, 0, R.style.AztecTextStyle)
         setLineSpacing(
                 array.getDimension(
                         R.styleable.AztecText_lineSpacingExtra,
@@ -129,6 +147,8 @@ class AztecText : EditText, TextWatcher {
 
         // triggers ClickableSpan onClick() events
         movementMethod = EnhancedMovementMethod
+
+        isViewInitialized = true
     }
 
     override fun onAttachedToWindow() {
@@ -139,6 +159,9 @@ class AztecText : EditText, TextWatcher {
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         removeTextChangedListener(this)
+        if (addLinkDialog != null && addLinkDialog!!.isShowing) {
+            addLinkDialog!!.dismiss()
+        }
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
@@ -156,6 +179,16 @@ class AztecText : EditText, TextWatcher {
         history.historyCursor = customState.getInt("historyCursor")
         history.inputLast = customState.getString("inputLast")
         visibility = customState.getInt("visibility")
+
+        val isDialogVisible = customState.getBoolean("isUrlDialogVisible", false)
+
+        if (isDialogVisible) {
+            val retainedUrl = customState.getString("retainedUrl", "")
+            val retainedAnchor = customState.getString("retainedAnchor", "")
+
+            showLinkDialog(retainedUrl, retainedAnchor)
+        }
+
     }
 
     override fun onSaveInstanceState(): Parcelable {
@@ -166,6 +199,17 @@ class AztecText : EditText, TextWatcher {
         bundle.putInt("historyCursor", history.historyCursor)
         bundle.putString("inputLast", history.inputLast)
         bundle.putInt("visibility", visibility)
+
+        if (addLinkDialog != null && addLinkDialog!!.isShowing) {
+            bundle.putBoolean("isUrlDialogVisible", true)
+
+            val urlInput = addLinkDialog!!.findViewById(R.id.linkURL) as EditText
+            val anchorInput = addLinkDialog!!.findViewById(R.id.linkText) as EditText
+
+            bundle.putString("retainedUrl", urlInput.text.toString())
+            bundle.putString("retainedAnchor", anchorInput.text.toString())
+        }
+
         savedState.state = bundle
         return savedState
     }
@@ -184,1034 +228,190 @@ class AztecText : EditText, TextWatcher {
 
     fun setSelectedStyles(styles: ArrayList<TextFormat>) {
         isNewStyleSelected = true
-        selectedStyles?.clear()
-        selectedStyles?.addAll(styles)
+        selectedStyles.clear()
+        selectedStyles.addAll(styles)
     }
 
     fun setOnSelectionChangedListener(onSelectionChangedListener: OnSelectionChangedListener) {
         this.onSelectionChangedListener = onSelectionChangedListener
     }
 
-    override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+    public override fun onSelectionChanged(selStart: Int, selEnd: Int) {
         super.onSelectionChanged(selStart, selEnd)
+        if (!isViewInitialized) return
+
         onSelectionChangedListener?.onSelectionChanged(selStart, selEnd)
 
         setSelectedStyles(getAppliedStyles(if (selStart > 0 && !isTextSelected()) selStart - 1 else selStart, selEnd))
-
     }
 
     // Inline Styles ===================================================================================
 
     private fun bold(valid: Boolean) {
         if (valid) {
-            applyInlineStyle(TextFormat.FORMAT_BOLD, selectionStart, selectionEnd)
+            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_BOLD, selectionStart, selectionEnd)
         } else {
-            removeInlineStyle(TextFormat.FORMAT_BOLD, selectionStart, selectionEnd)
+            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_BOLD, selectionStart, selectionEnd)
         }
     }
 
     private fun italic(valid: Boolean) {
         if (valid) {
-            applyInlineStyle(TextFormat.FORMAT_ITALIC, selectionStart, selectionEnd)
+            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_ITALIC, selectionStart, selectionEnd)
         } else {
-            removeInlineStyle(TextFormat.FORMAT_ITALIC, selectionStart, selectionEnd)
+            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_ITALIC, selectionStart, selectionEnd)
         }
     }
 
     fun underline(valid: Boolean) {
         if (valid) {
-            applyInlineStyle(TextFormat.FORMAT_UNDERLINED, selectionStart, selectionEnd)
+            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_UNDERLINED, selectionStart, selectionEnd)
         } else {
-            removeInlineStyle(TextFormat.FORMAT_UNDERLINED, selectionEnd, selectionEnd)
+            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_UNDERLINED, selectionEnd, selectionEnd)
         }
     }
 
     fun strikethrough(valid: Boolean) {
         if (valid) {
-            applyInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selectionStart, selectionEnd)
+            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selectionStart, selectionEnd)
         } else {
-            removeInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selectionStart, selectionEnd)
+            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selectionStart, selectionEnd)
         }
     }
 
-    fun isSameInlineSpanType(firstSpan: AztecInlineSpan, secondSpan: AztecInlineSpan): Boolean {
-        if (firstSpan.javaClass.equals(secondSpan.javaClass)) {
-            //special check for StyleSpan
-            if (firstSpan is StyleSpan && secondSpan is StyleSpan) {
-                return firstSpan.style == secondSpan.style
-            } else {
-                return true
-            }
-
-        }
-
-        return false
-    }
-
-    //TODO: Check if there is more efficient way to tidy spans
-    private fun joinStyleSpans(start: Int, end: Int) {
-        //joins spans on the left
-        if (start > 1) {
-            val spansInSelection = editableText.getSpans(start, end, AztecInlineSpan::class.java)
-
-            val spansBeforeSelection = editableText.getSpans(start - 1, start, AztecInlineSpan::class.java)
-            spansInSelection.forEach { innerSpan ->
-                val inSelectionSpanEnd = editableText.getSpanEnd(innerSpan)
-
-                spansBeforeSelection.forEach { outerSpan ->
-                    val outerSpanStart = editableText.getSpanStart(outerSpan)
-
-                    if (isSameInlineSpanType(innerSpan, outerSpan)) {
-                        editableText.removeSpan(outerSpan)
-                        editableText.setSpan(innerSpan, outerSpanStart, inSelectionSpanEnd, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-                    }
-
-                }
-            }
-        }
-
-        //joins spans on the right
-        if (length() > end) {
-            val spansInSelection = editableText.getSpans(start, end, AztecInlineSpan::class.java)
-            val spansAfterSelection = editableText.getSpans(end, end + 1, AztecInlineSpan::class.java)
-            spansInSelection.forEach { innerSpan ->
-                val inSelectionSpanStart = editableText.getSpanStart(innerSpan)
-
-                spansAfterSelection.forEach { outerSpan ->
-                    val outerSpanEnd = editableText.getSpanEnd(outerSpan)
-
-                    if (isSameInlineSpanType(innerSpan, outerSpan)) {
-                        editableText.removeSpan(outerSpan)
-                        editableText.setSpan(innerSpan, inSelectionSpanStart, outerSpanEnd, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-                    }
-                }
-            }
-        }
-
-
-        //joins spans withing selected text
-        val spansInSelection = editableText.getSpans(start, end, AztecInlineSpan::class.java)
-        val spansToUse = editableText.getSpans(start, end, AztecInlineSpan::class.java)
-
-        spansInSelection.forEach { appliedSpan ->
-
-            val spanStart = editableText.getSpanStart(appliedSpan)
-            val spanEnd = editableText.getSpanEnd(appliedSpan)
-
-            var neighbourSpan: AztecInlineSpan? = null
-
-            spansToUse.forEach inner@ {
-                val aSpanStart = editableText.getSpanStart(it)
-                val aSpanEnd = editableText.getSpanEnd(it)
-                if (isSameInlineSpanType(it, appliedSpan)) {
-                    if (aSpanStart == spanEnd || aSpanEnd == spanStart) {
-                        neighbourSpan = it
-                        return@inner
-                    }
-
-                }
-            }
-
-            if (neighbourSpan != null) {
-                val neighbourSpanStart = editableText.getSpanStart(neighbourSpan)
-                val neighbourSpanEnd = editableText.getSpanEnd(neighbourSpan)
-
-                if (neighbourSpanStart == -1 || neighbourSpanEnd == -1)
-                    return@forEach
-
-                //span we want to join is on the left
-                if (spanStart == neighbourSpanEnd) {
-                    editableText.setSpan(appliedSpan, neighbourSpanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-                } else if (spanEnd == neighbourSpanStart) {
-                    editableText.setSpan(appliedSpan, spanStart, neighbourSpanEnd, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-                }
-
-                editableText.removeSpan(neighbourSpan)
-            }
-        }
-    }
-
-    private fun applyInlineStyle(textFormat: TextFormat, start: Int, end: Int) {
-        val spanToApply = makeInlineSpan(textFormat)
-
-        if (start >= end) {
-            return
-        }
-
-        var precedingSpan: AztecInlineSpan? = null
-        var followingSpan: AztecInlineSpan? = null
-
-        if (start >= 1) {
-            val previousSpans = editableText.getSpans(start - 1, start, AztecInlineSpan::class.java)
-            previousSpans.forEach {
-                if (isSameInlineSpanType(it, spanToApply)) {
-                    precedingSpan = it
-                    return@forEach
-                }
-            }
-
-            if (precedingSpan != null) {
-                val spanStart = editableText.getSpanStart(precedingSpan)
-                val spanEnd = editableText.getSpanEnd(precedingSpan)
-
-                if (spanEnd > start) {
-                    return@applyInlineStyle  //we are adding text inside span - no need to do anything special
-                } else {
-                    editableText.setSpan(precedingSpan, spanStart, end, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-                }
-
-            }
-        }
-
-        if (length() > end) {
-            val nextSpans = editableText.getSpans(end, end + 1, AztecInlineSpan::class.java)
-            nextSpans.forEach {
-                if (isSameInlineSpanType(it, spanToApply)) {
-                    followingSpan = it
-                    return@forEach
-                }
-            }
-
-            if (followingSpan != null) {
-                val spanEnd = editableText.getSpanEnd(followingSpan)
-                editableText.setSpan(followingSpan, start, spanEnd, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-            }
-        }
-
-        if (precedingSpan == null && followingSpan == null) {
-            var existingSpanOfSameStyle: AztecInlineSpan? = null
-
-            val spans = editableText.getSpans(start, end, AztecInlineSpan::class.java)
-            spans.forEach {
-                if (isSameInlineSpanType(it, spanToApply)) {
-                    existingSpanOfSameStyle = it
-                    return@forEach
-                }
-            }
-
-            //if we already have same span within selection - reuse it by changing it's bounds
-            if (existingSpanOfSameStyle != null) {
-                editableText.removeSpan(existingSpanOfSameStyle)
-                editableText.setSpan(existingSpanOfSameStyle, start, end, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-            } else {
-                editableText.setSpan(spanToApply, start, end, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-            }
-
-        }
-
-        joinStyleSpans(start, end)
-    }
-
-    fun removeInlineStyle(textFormat: TextFormat, start: Int, end: Int) {
-        //for convenience sake we are initializing the span of same type we are planing to remove
-        val spanToRemove = makeInlineSpan(textFormat)
-
-        if (start >= end) {
-            return
-        }
-
-
-        val spans = editableText.getSpans(start, end, AztecInlineSpan::class.java)
-        val list = ArrayList<AztecPart>()
-
-        spans.forEach {
-            if (isSameInlineSpanType(it, spanToRemove)) {
-                list.add(AztecPart(editableText.getSpanStart(it), editableText.getSpanEnd(it)))
-                editableText.removeSpan(it)
-            }
-        }
-
-        list.forEach {
-            if (it.isValid) {
-                if (it.start < start) {
-                    applyInlineStyle(textFormat, it.start, start)
-                }
-                if (it.end > end) {
-                    applyInlineStyle(textFormat, end, it.end)
-                }
-            }
-        }
-
-        joinStyleSpans(start, end)
-    }
-
-    //TODO: Come up with a better way to init spans and get their classes (all the "make" methods)
-    fun makeBlockSpan(textFormat: TextFormat, attrs: String? = null): AztecBlockSpan {
-        when (textFormat) {
-            TextFormat.FORMAT_ORDERED_LIST -> return AztecOrderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
-            TextFormat.FORMAT_UNORDERED_LIST -> return AztecUnorderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
-            TextFormat.FORMAT_QUOTE -> return AztecQuoteSpan(quoteBackground, quoteColor, quoteMargin, quoteWidth, quotePadding, attrs)
-            else -> return ParagraphSpan(attrs)
-        }
-    }
-
-
-    fun makeBlockSpan(spanType: Class<AztecBlockSpan>, attrs: String? = null): AztecBlockSpan {
-        when (spanType) {
-            AztecOrderedListSpan::class.java -> return AztecOrderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
-            AztecUnorderedListSpan::class.java -> return AztecUnorderedListSpan(bulletColor, bulletMargin, bulletWidth, bulletPadding, attrs)
-            AztecQuoteSpan::class.java -> return AztecQuoteSpan(quoteBackground, quoteColor, quoteMargin, quoteWidth, quotePadding, attrs)
-            else -> return ParagraphSpan(attrs)
-        }
-    }
-
-    fun makeInlineSpan(textFormat: TextFormat): AztecInlineSpan {
-        when (textFormat) {
-            TextFormat.FORMAT_HEADING_1 -> return AztecHeadingSpan(Heading.H1)
-            TextFormat.FORMAT_HEADING_2 -> return AztecHeadingSpan(Heading.H2)
-            TextFormat.FORMAT_HEADING_3 -> return AztecHeadingSpan(Heading.H3)
-            TextFormat.FORMAT_HEADING_4 -> return AztecHeadingSpan(Heading.H4)
-            TextFormat.FORMAT_HEADING_5 -> return AztecHeadingSpan(Heading.H5)
-            TextFormat.FORMAT_HEADING_6 -> return AztecHeadingSpan(Heading.H6)
-            TextFormat.FORMAT_BOLD -> return AztecStyleSpan(Typeface.BOLD)
-            TextFormat.FORMAT_ITALIC -> return AztecStyleSpan(Typeface.ITALIC)
-            TextFormat.FORMAT_STRIKETHROUGH -> return AztecStrikethroughSpan()
-            TextFormat.FORMAT_UNDERLINED -> return AztecUnderlineSpan()
-            else -> return AztecStyleSpan(Typeface.NORMAL)
-        }
-    }
-
-    fun containsInlineStyle(textFormat: TextFormat, start: Int, end: Int): Boolean {
-        val spanToCheck = makeInlineSpan(textFormat)
-
-        if (start > end) {
-            return false
-        }
-
-        if (start == end) {
-            if (start - 1 < 0 || start + 1 > editableText.length) {
-                return false
-            } else {
-                val before = editableText.getSpans(start - 1, start, AztecInlineSpan::class.java)
-                        .filter { it -> isSameInlineSpanType(it, spanToCheck) }
-                val after = editableText.getSpans(start, start + 1, AztecInlineSpan::class.java)
-                        .filter { isSameInlineSpanType(it, spanToCheck) }
-                return before.size > 0 && after.size > 0 && isSameInlineSpanType(before[0], after[0])
-            }
-        } else {
-            val builder = StringBuilder()
-
-            // Make sure no duplicate characters be added
-            for (i in start..end - 1) {
-                val spans = editableText.getSpans(i, i + 1, AztecInlineSpan::class.java)
-                for (span in spans) {
-                    if (isSameInlineSpanType(span, spanToCheck)) {
-                        builder.append(editableText.subSequence(i, i + 1).toString())
-                        break
-                    }
-                }
-            }
-
-            return editableText.subSequence(start, end).toString() == builder.toString()
-        }
-
-    }
 
     // HeadingSpan =================================================================================
 
     fun heading(format: Boolean, textFormat: TextFormat) {
-        headingClear()
+        lineBlockFormatter.headingClear()
 
         if (format) {
-            headingFormat(textFormat)
+            lineBlockFormatter.headingFormat(textFormat)
         }
     }
 
-    private fun headingClear() {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-
-        for (i in lines.indices) {
-            if (!containsHeading(i)) {
-                continue
-            }
-
-            var lineStart = 0
-
-            for (j in 0..i - 1) {
-                lineStart += lines[j].length + 1
-            }
-
-            val lineEnd = lineStart + lines[i].length
-
-            if (lineStart >= lineEnd) {
-                continue
-            }
-
-            var headingStart = 0
-            var headingEnd = 0
-
-            if ((lineStart <= selectionStart && selectionEnd <= lineEnd) ||
-                    (lineStart >= selectionStart && selectionEnd >= lineEnd) ||
-                    (lineStart <= selectionStart && selectionEnd >= lineEnd && selectionStart <= lineEnd) ||
-                    (lineStart >= selectionStart && selectionEnd <= lineEnd && selectionEnd >= lineStart)) {
-                headingStart = lineStart
-                headingEnd = lineEnd
-            }
-
-            if (headingStart < headingEnd) {
-                val spans = editableText.getSpans(headingStart, headingEnd, AztecHeadingSpan::class.java)
-
-                for (span in spans) {
-                    editableText.removeSpan(span)
-                }
-            }
-        }
-
-        refreshText()
-    }
-
-    private fun headingFormat(textFormat: TextFormat) {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-
-        for (i in lines.indices) {
-            var lineStart = 0
-
-            for (j in 0..i - 1) {
-                lineStart += lines[j].length + 1
-            }
-
-            val lineEnd = lineStart + lines[i].length
-
-            if (lineStart >= lineEnd) {
-                continue
-            }
-
-            var headingStart = 0
-            var headingEnd = 0
-
-            if ((lineStart <= selectionStart && selectionEnd <= lineEnd) ||
-                    (lineStart >= selectionStart && selectionEnd >= lineEnd) ||
-                    (lineStart <= selectionStart && selectionEnd >= lineEnd && selectionStart <= lineEnd) ||
-                    (lineStart >= selectionStart && selectionEnd <= lineEnd && selectionEnd >= lineStart)) {
-                headingStart = lineStart
-                headingEnd = lineEnd
-            }
-
-            if (headingStart < headingEnd) {
-                when (textFormat) {
-                    TextFormat.FORMAT_HEADING_1 ->
-                        editableText.setSpan(AztecHeadingSpan(Heading.H1), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    TextFormat.FORMAT_HEADING_2 ->
-                        editableText.setSpan(AztecHeadingSpan(Heading.H2), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    TextFormat.FORMAT_HEADING_3 ->
-                        editableText.setSpan(AztecHeadingSpan(Heading.H3), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    TextFormat.FORMAT_HEADING_4 ->
-                        editableText.setSpan(AztecHeadingSpan(Heading.H4), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    TextFormat.FORMAT_HEADING_5 ->
-                        editableText.setSpan(AztecHeadingSpan(Heading.H5), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    TextFormat.FORMAT_HEADING_6 ->
-                        editableText.setSpan(AztecHeadingSpan(Heading.H6), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                    else -> {
-                    }
-                }
-            }
-        }
-
-        refreshText()
-    }
-
-    private fun containsHeading(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-        val list = ArrayList<Int>()
-
-        for (i in lines.indices) {
-            var lineStart = 0
-            for (j in 0..i - 1) {
-                lineStart += lines[j].length + 1
-            }
-
-            val lineEnd = lineStart + lines[i].length
-            if (lineStart >= lineEnd) {
-                continue
-            }
-
-            if (lineStart <= selStart && selEnd <= lineEnd) {
-                list.add(i)
-            } else if (selStart <= lineStart && lineEnd <= selEnd) {
-                list.add(i)
-            }
-        }
-
-        if (list.isEmpty()) return false
-
-        for (i in list) {
-            if (!containHeadingType(textFormat, i)) {
-                return false
-            }
-        }
-
-        return true
-    }
-
-    private fun containsHeading(index: Int): Boolean {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-
-        if (index < 0 || index >= lines.size) {
-            return false
-        }
-
-        var start = 0
-
-        for (i in 0..index - 1) {
-            start += lines[i].length + 1
-        }
-
-        val end = start + lines[index].length
-
-        if (start >= end) {
-            return false
-        }
-
-        val spans = editableText.getSpans(start, end, AztecHeadingSpan::class.java)
-        return spans.size > 0
-    }
-
-    private fun containHeadingType(textFormat: TextFormat, index: Int): Boolean {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-
-        if (index < 0 || index >= lines.size) {
-            return false
-        }
-
-        var start = 0
-
-        for (i in 0..index - 1) {
-            start += lines[i].length + 1
-        }
-
-        val end = start + lines[index].length
-
-        if (start >= end) {
-            return false
-        }
-
-        val spans = editableText.getSpans(start, end, AztecHeadingSpan::class.java)
-
-        for (span in spans) {
-            when (textFormat) {
-                TextFormat.FORMAT_HEADING_1 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H1)
-                TextFormat.FORMAT_HEADING_2 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H2)
-                TextFormat.FORMAT_HEADING_3 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H3)
-                TextFormat.FORMAT_HEADING_4 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H4)
-                TextFormat.FORMAT_HEADING_5 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H5)
-                TextFormat.FORMAT_HEADING_6 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H6)
-                else -> return false
-            }
-        }
-
-        return false
-    }
 
     // BulletSpan ==================================================================================
 
-    fun orderedListValid(valid: Boolean) {
+    fun orderedList(valid: Boolean) {
         if (valid) {
-            if (containsList(TextFormat.FORMAT_UNORDERED_LIST, selectionStart, selectionEnd)) {
-                switchListType(TextFormat.FORMAT_ORDERED_LIST)
+            if (blockFormatter.containsList(TextFormat.FORMAT_UNORDERED_LIST, selectionStart, selectionEnd)) {
+                blockFormatter.switchListType(TextFormat.FORMAT_ORDERED_LIST)
             } else {
-                applyBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
+                blockFormatter.applyBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
             }
         } else {
-            removeBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
+            blockFormatter.removeBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
         }
     }
 
-    fun unorderedListValid(valid: Boolean) {
+    fun unorderedList(valid: Boolean) {
         if (valid) {
-            if (containsList(TextFormat.FORMAT_ORDERED_LIST, selectionStart, selectionEnd)) {
-                switchListType(TextFormat.FORMAT_UNORDERED_LIST)
+            if (blockFormatter.containsList(TextFormat.FORMAT_ORDERED_LIST, selectionStart, selectionEnd)) {
+                blockFormatter.switchListType(TextFormat.FORMAT_UNORDERED_LIST)
             } else {
-                applyBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
+                blockFormatter.applyBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
             }
         } else {
-            removeBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
+            blockFormatter.removeBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
         }
     }
 
-    private fun switchListType(listTypeToSwitchTo: TextFormat, start: Int = selectionStart, end: Int = selectionEnd) {
-        val spans = editableText.getSpans(start, end, AztecListSpan::class.java)
-
-        if (spans.isEmpty()) return
-
-        val existingListSpan = spans[0]
-
-        val spanStart = editableText.getSpanStart(existingListSpan)
-        val spanEnd = editableText.getSpanEnd(existingListSpan)
-        val spanFlags = editableText.getSpanFlags(existingListSpan)
-        editableText.removeSpan(existingListSpan)
-
-        editableText.setSpan(makeBlockSpan(listTypeToSwitchTo), spanStart, spanEnd, spanFlags)
-        onSelectionChanged(start, end)
-    }
-
-    private fun applyBlockStyle(blockElementType: TextFormat, start: Int = selectionStart, end: Int = selectionEnd) {
-        if (start != end) {
-            val selectedText = editableText.substring(start + 1..end - 1)
-
-            //multiline text selected
-            if (selectedText.indexOf("\n") != -1) {
-                val indexOfFirstLineBreak = editableText.indexOf("\n", end)
-
-                val endOfBlock = if (indexOfFirstLineBreak != -1) indexOfFirstLineBreak else editableText.length
-                val startOfBlock = editableText.lastIndexOf("\n", start)
-
-                val selectedLines = editableText.subSequence(startOfBlock + 1..endOfBlock - 1) as Editable
-
-                var numberOfLinesWithSpanApplied = 0
-                var numberOfLines = 0
-
-                val lines = TextUtils.split(selectedLines.toString(), "\n")
-
-                for (i in lines.indices) {
-                    numberOfLines++
-                    if (containsList(blockElementType, i, selectedLines)) {
-                        numberOfLinesWithSpanApplied++
-                    }
-                }
-
-                if (numberOfLines == numberOfLinesWithSpanApplied) {
-                    removeBlockStyle(blockElementType)
-                } else {
-                    editableText.setSpan(makeBlockSpan(blockElementType), startOfBlock + 1, endOfBlock, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-                }
-            }
-
-        } else {
-            val boundsOfSelectedText = getSelectedTextBounds(editableText, start, end)
-
-            val startOfLine = boundsOfSelectedText.start
-            var endOfLine = boundsOfSelectedText.endInclusive
-
-            val isEmptyLine = startOfLine == endOfLine
-
-            if (isEmptyLine) {
-                disableTextChangedListener()
-                editableText.insert(startOfLine, "\u200B")
-                endOfLine += 1
-            }
-
-            val spanToApply = makeBlockSpan(blockElementType)
-
-            var startOfBlock: Int = startOfLine
-            var endOfBlock: Int = endOfLine
 
 
-            if (startOfLine != 0) {
-                val spansOnPreviousLine = editableText.getSpans(startOfLine - 1, startOfLine - 1, spanToApply.javaClass)
-                if (!spansOnPreviousLine.isEmpty()) {
-                    startOfBlock = editableText.getSpanStart(spansOnPreviousLine[0])
-                    editableText.removeSpan(spansOnPreviousLine[0])
-                }
-            }
-
-            if (endOfLine != editableText.length) {
-                val spanOnNextLine = editableText.getSpans(endOfLine + 1, endOfLine + 1, spanToApply.javaClass)
-                if (!spanOnNextLine.isEmpty()) {
-                    endOfBlock = editableText.getSpanEnd(spanOnNextLine[0])
-                    editableText.removeSpan(spanOnNextLine[0])
-                }
-            }
-
-            editableText.setSpan(spanToApply, startOfBlock, endOfBlock, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-
-            //if the line was empty trigger onSelectionChanged manually to update toolbar buttons status
-            if (isEmptyLine) {
-                onSelectionChanged(startOfLine, endOfLine)
-            }
-        }
-    }
-
-    private fun removeBlockStyle(textFormat: TextFormat) {
-        removeBlockStyle(selectionStart, selectionEnd, makeBlockSpan(textFormat).javaClass)
-    }
-
-    private fun removeBlockStyle(start: Int = selectionStart, end: Int = selectionEnd,
-                                 spanType: Class<AztecBlockSpan> = AztecBlockSpan::class.java, ignoreLineBounds: Boolean = false) {
-        val spans = editableText.getSpans(start, end, spanType)
-        spans.forEach {
-
-            val spanStart = editableText.getSpanStart(it)
-            var spanEnd = editableText.getSpanEnd(it)
-
-            //if splitting block set a range that would be excluded from it
-            val boundsOfSelectedText = if (ignoreLineBounds) IntRange(start, end) else getSelectedTextBounds(editableText, start, end)
-
-            val startOfLine = boundsOfSelectedText.start
-            val endOfLine = boundsOfSelectedText.endInclusive
-
-            val spanPrecedesLine = spanStart < startOfLine
-            val spanExtendsBeyondLine = endOfLine < spanEnd
-
-            //remove the span from all the selected lines
-            editableText.removeSpan(it)
-
-
-            //reapply span top "top" and "bottom"
-            if (spanPrecedesLine) {
-                editableText.setSpan(makeBlockSpan(it.javaClass), spanStart, startOfLine - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
-
-            if (spanExtendsBeyondLine) {
-                if (editableText[endOfLine] == '\n' && !ignoreLineBounds) {
-                    disableTextChangedListener()
-                    editableText.delete(endOfLine, endOfLine + 1)
-                    spanEnd--
-                }
-
-                editableText.setSpan(makeBlockSpan(it.javaClass), endOfLine, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
-
-        }
-
-
-    }
-
-    private fun containsList(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-        val list = ArrayList<Int>()
-
-
-        for (i in lines.indices) {
-            var lineStart = 0
-            for (j in 0..i - 1) {
-                lineStart += lines[j].length + 1
-            }
-
-            val lineEnd = lineStart + lines[i].length
-            if (lineStart > lineEnd) {
-                continue
-            }
-
-            if (lineStart <= selStart && selEnd <= lineEnd) {
-                list.add(i)
-            } else if (selStart <= lineStart && lineEnd <= selEnd) {
-                list.add(i)
-            }
-        }
-
-        if (list.isEmpty()) return false
-
-        for (i in list) {
-            if (!containsList(textFormat, i)) {
-                return false
-            }
-        }
-
-        return true
-    }
-
-    private fun containsList(textFormat: TextFormat, index: Int, text: Editable = editableText): Boolean {
-        val lines = TextUtils.split(text.toString(), "\n")
-        if (index < 0 || index >= lines.size) {
-            return false
-        }
-
-        var start = 0
-        for (i in 0..index - 1) {
-            start += lines[i].length + 1
-        }
-
-        val end = start + lines[index].length
-        if (start > end) {
-            return false
-        }
-
-        val spans = editableText.getSpans(start, end, makeBlockSpan(textFormat).javaClass)
-        return spans.size > 0
-    }
 
     // QuoteSpan ===================================================================================
 
     fun quote(valid: Boolean) {
         if (valid) {
-            applyBlockStyle(TextFormat.FORMAT_QUOTE)
+            blockFormatter.applyBlockStyle(TextFormat.FORMAT_QUOTE)
         } else {
-            removeBlockStyle(TextFormat.FORMAT_QUOTE)
+            blockFormatter.removeBlockStyle(TextFormat.FORMAT_QUOTE)
         }
     }
 
-    private fun containQuote(selStart: Int, selEnd: Int): Boolean {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-        val list = ArrayList<Int>()
-
-        for (i in lines.indices) {
-            var lineStart = 0
-            for (j in 0..i - 1) {
-                lineStart += lines[j].length + 1
-            }
-
-            val lineEnd = lineStart + lines[i].length
-            if (lineStart >= lineEnd) {
-                continue
-            }
-
-            if (lineStart <= selStart && selEnd <= lineEnd) {
-                list.add(i)
-            } else if (selStart <= lineStart && lineEnd <= selEnd) {
-                list.add(i)
-            }
-        }
-
-        if (list.isEmpty()) return false
-
-        for (i in list) {
-            if (!containQuote(i)) {
-                return false
-            }
-        }
-
-        return true
-    }
-
-    private fun containQuote(index: Int): Boolean {
-        val lines = TextUtils.split(editableText.toString(), "\n")
-        if (index < 0 || index >= lines.size) {
-            return false
-        }
-
-        var start = 0
-        for (i in 0..index - 1) {
-            start += lines[i].length + 1
-        }
-
-        val end = start + lines[index].length
-        if (start >= end) {
-            return false
-        }
-
-        val spans = editableText.getSpans(start, end, AztecQuoteSpan::class.java)
-        return spans.size > 0
-    }
 
     fun getSelectedText(): String {
         if (selectionStart == -1 || selectionEnd == -1) return ""
         return editableText.substring(selectionStart, selectionEnd)
     }
 
-    fun isUrlSelected(): Boolean {
-        val urlSpans = editableText.getSpans(selectionStart, selectionEnd, AztecURLSpan::class.java)
-        return !urlSpans.isEmpty()
-    }
 
-    fun getSelectedUrlWithAnchor(): Pair<String, String> {
-        val url: String
-        var anchor: String
-
-        if (!isUrlSelected()) {
-            val clipboardUrl = getUrlFromClipboard(context)
-
-            url = if (TextUtils.isEmpty(clipboardUrl)) "" else clipboardUrl
-            anchor = if (selectionStart == selectionEnd) "" else getSelectedText()
-
-        } else {
-            val urlSpans = editableText.getSpans(selectionStart, selectionEnd, AztecURLSpan::class.java)
-            val urlSpan = urlSpans[0]
-
-            val spanStart = editableText.getSpanStart(urlSpan)
-            val spanEnd = editableText.getSpanEnd(urlSpan)
-
-            if (selectionStart < spanStart || selectionEnd > spanEnd) {
-                //looks like some text that is not part of the url was included in selection
-                anchor = getSelectedText()
-                url = ""
-            } else {
-                anchor = editableText.substring(spanStart, spanEnd)
-                url = urlSpan.url
-            }
-
-            if (anchor == url) {
-                anchor = ""
+    fun getAppliedStyles(selectionStart: Int, selectionEnd: Int): ArrayList<TextFormat> {
+        val styles = ArrayList<TextFormat>()
+        TextFormat.values().forEach {
+            if (contains(it, selectionStart, selectionEnd)) {
+                styles.add(it)
             }
         }
-
-        return Pair(url, anchor)
-
+        return styles
     }
 
-    /**
-     * Checks the Clipboard for text that matches the [Patterns.WEB_URL] pattern.
-     * @return the URL text in the clipboard, if it exists; otherwise null
-     */
-    fun getUrlFromClipboard(context: Context?): String {
-        if (context == null) return ""
-        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-
-        val data = clipboard.primaryClip
-        if (data == null || data.itemCount <= 0) return ""
-        val clipText = data.getItemAt(0).text.toString()
-        return if (Patterns.WEB_URL.matcher(clipText).matches()) clipText else ""
+    fun isEmpty(): Boolean {
+        return text.isEmpty()
     }
 
-    fun getUrlSpanBounds(): Pair<Int, Int> {
-        val urlSpans = editableText.getSpans(selectionStart, selectionEnd, AztecURLSpan::class.java)
-
-        val spanStart = text.getSpanStart(urlSpans[0])
-        val spanEnd = text.getSpanEnd(urlSpans[0])
-
-        if (selectionStart < spanStart || selectionEnd > spanEnd) {
-            //looks like some text that is not part of the url was included in selection
-            return Pair(selectionStart, selectionEnd)
-        }
-        return Pair(spanStart, spanEnd)
+    fun formattingIsApplied(): Boolean {
+        return !selectedStyles.isEmpty()
     }
 
-    fun link(url: String, anchor: String) {
-        if (TextUtils.isEmpty(url) && isUrlSelected()) {
-            removeLink()
-        } else if (isUrlSelected()) {
-            editLink(url, anchor, getUrlSpanBounds().first, getUrlSpanBounds().second)
-        } else {
-            addLink(url, anchor, selectionStart, selectionEnd)
-        }
+    fun formattingHasChanged(): Boolean {
+        return isNewStyleSelected
     }
 
-    fun addLink(link: String, anchor: String, start: Int, end: Int) {
-        val cleanLink = link.trim()
-        val newEnd: Int
-
-        val actuallAnchor = if (TextUtils.isEmpty(anchor)) cleanLink else anchor
-
-        if (start == end) {
-            //insert anchor
-            text.insert(start, actuallAnchor)
-            newEnd = start + actuallAnchor.length
-        } else {
-            //apply span to text
-            if (!getSelectedText().equals(anchor)) {
-                text.replace(start, end, actuallAnchor)
-            }
-            newEnd = start + actuallAnchor.length
-        }
-
-        linkValid(link, start, newEnd)
+    fun setFormattingChangesApplied() {
+        isNewStyleSelected = false
     }
 
-    fun editLink(link: String, anchor: String?, start: Int = selectionStart, end: Int = selectionEnd) {
-        val cleanLink = link.trim()
-        val newEnd: Int
 
-        if (TextUtils.isEmpty(anchor)) {
-            text.replace(start, end, cleanLink)
-            newEnd = start + cleanLink.length
-        } else {
-            //if the anchor was not changed do nothing to preserve original style of text
-            if (!getSelectedText().equals(anchor)) {
-                text.replace(start, end, anchor)
-            }
-            newEnd = start + anchor!!.length
-        }
-
-        var attributes = getAttributes(end, start)
-        attributes = attributes?.replace("href=[\"'].*[\"']".toRegex(), "href=\"$cleanLink\"")
-
-        linkValid(cleanLink, start, newEnd, attributes)
+    fun isTextSelected(): Boolean {
+        return selectionStart != selectionEnd
     }
 
-    private fun getAttributes(end: Int, start: Int): String? {
-        val urlSpans = editableText.getSpans(start, end, AztecURLSpan::class.java)
-        var attributes: String? = null
-        if (urlSpans != null && urlSpans.size > 0) {
-            attributes = urlSpans[0].attributes
-        }
-        return attributes
-    }
+    fun toggleFormatting(textFormat: TextFormat) {
+        history.beforeTextChanged(toFormattedHtml())
 
-    fun removeLink() {
-        val urlSpanBounds = getUrlSpanBounds()
-
-        linkInvalid(urlSpanBounds.first, urlSpanBounds.second)
-        onSelectionChanged(urlSpanBounds.first, urlSpanBounds.second)
-    }
-
-    private fun linkValid(link: String, start: Int, end: Int, attributes: String? = null) {
-        if (start >= end) {
-            return
-        }
-
-        linkInvalid(start, end)
-        editableText.setSpan(AztecURLSpan(link, linkColor, linkUnderline, attributes), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        onSelectionChanged(end, end)
-    }
-
-    private fun linkInvalid(start: Int, end: Int) {
-        if (start >= end) {
-            return
-        }
-
-        val spans = editableText.getSpans(start, end, AztecURLSpan::class.java)
-        for (span in spans) {
-            editableText.removeSpan(span)
-        }
-    }
-
-    private fun containLink(start: Int, end: Int): Boolean {
-        if (start > end) {
-            return false
-        }
-
-        if (start == end) {
-            if (start - 1 < 0 || start + 1 > editableText.length) {
-                return false
-            } else {
-                val before = editableText.getSpans(start - 1, start, AztecURLSpan::class.java)
-                val after = editableText.getSpans(start, start + 1, AztecURLSpan::class.java)
-                return before.size > 0 && after.size > 0
-            }
-        } else {
-            val builder = StringBuilder()
-
-            for (i in start..end - 1) {
-                if (editableText.getSpans(i, i + 1, AztecURLSpan::class.java).size > 0) {
-                    builder.append(editableText.subSequence(i, i + 1).toString())
-                }
-            }
-
-            return editableText.subSequence(start, end).toString() == builder.toString()
-        }
-    }
-
-    fun applyComment(comment: AztecCommentSpan.Comment) {
-        //check if we add a comment into a block element, at the end of the line, but not at the end of last line
-        var applyingOnTheEndOfBlockLine = false
-        editableText.getSpans(selectionStart, selectionEnd, AztecBlockSpan::class.java).forEach {
-            if (editableText.getSpanEnd(it) > selectionEnd && editableText[selectionEnd] == '\n') {
-                applyingOnTheEndOfBlockLine = true
-                return@forEach
+        when (textFormat) {
+            TextFormat.FORMAT_PARAGRAPH -> heading(false, textFormat)
+            TextFormat.FORMAT_HEADING_1,
+            TextFormat.FORMAT_HEADING_2,
+            TextFormat.FORMAT_HEADING_3,
+            TextFormat.FORMAT_HEADING_4,
+            TextFormat.FORMAT_HEADING_5,
+            TextFormat.FORMAT_HEADING_6 -> heading(true, textFormat)
+            TextFormat.FORMAT_BOLD -> bold(!contains(TextFormat.FORMAT_BOLD))
+            TextFormat.FORMAT_ITALIC -> italic(!contains(TextFormat.FORMAT_ITALIC))
+            TextFormat.FORMAT_STRIKETHROUGH -> strikethrough(!contains(TextFormat.FORMAT_STRIKETHROUGH))
+            TextFormat.FORMAT_UNORDERED_LIST -> unorderedList(!contains(TextFormat.FORMAT_UNORDERED_LIST))
+            TextFormat.FORMAT_ORDERED_LIST -> orderedList(!contains(TextFormat.FORMAT_ORDERED_LIST))
+            TextFormat.FORMAT_QUOTE -> quote(!contains(TextFormat.FORMAT_QUOTE))
+            TextFormat.FORMAT_MORE -> lineBlockFormatter.applyComment(AztecCommentSpan.Comment.MORE)
+            TextFormat.FORMAT_PAGE -> lineBlockFormatter.applyComment(AztecCommentSpan.Comment.PAGE)
+            else -> {
             }
         }
 
-        val commentStartIndex = selectionStart + 1
-        val commentEndIndex = selectionStart + comment.html.length + 1
+        history.handleHistory(this)
+    }
 
-        disableTextChangedListener()
-        editableText.replace(selectionStart, selectionEnd, "\n" + comment.html + if (applyingOnTheEndOfBlockLine) "" else "\n")
-
-        removeBlockStylesFromRange(commentStartIndex, commentEndIndex + 1, true)
-        removeHeadingStylesFromRange(commentStartIndex, commentEndIndex + 1)
-        removeInlineStylesFromRange(commentStartIndex, commentEndIndex + 1)
-
-        val span = AztecCommentSpan(
-                context,
-                when (comment) {
-                    AztecCommentSpan.Comment.MORE -> resources.getDrawable(R.drawable.img_more)
-                    AztecCommentSpan.Comment.PAGE -> resources.getDrawable(R.drawable.img_page)
-                }
-        )
-
-        editableText.setSpan(
-                span,
-                commentStartIndex,
-                commentEndIndex,
-                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-        )
-
-        setSelection(commentEndIndex + 1)
+    fun contains(format: TextFormat, selStart: Int = selectionStart, selEnd: Int = selectionEnd): Boolean {
+        when (format) {
+            TextFormat.FORMAT_HEADING_1,
+            TextFormat.FORMAT_HEADING_2,
+            TextFormat.FORMAT_HEADING_3,
+            TextFormat.FORMAT_HEADING_4,
+            TextFormat.FORMAT_HEADING_5,
+            TextFormat.FORMAT_HEADING_6 -> return lineBlockFormatter.containsHeading(format, selStart, selEnd)
+            TextFormat.FORMAT_BOLD -> return inlineFormatter.containsInlineStyle(TextFormat.FORMAT_BOLD, selStart, selEnd)
+            TextFormat.FORMAT_ITALIC -> return inlineFormatter.containsInlineStyle(TextFormat.FORMAT_ITALIC, selStart, selEnd)
+            TextFormat.FORMAT_UNDERLINED -> return inlineFormatter.containsInlineStyle(TextFormat.FORMAT_UNDERLINED, selStart, selEnd)
+            TextFormat.FORMAT_STRIKETHROUGH -> return inlineFormatter.containsInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selStart, selEnd)
+            TextFormat.FORMAT_UNORDERED_LIST -> return blockFormatter.containsList(TextFormat.FORMAT_UNORDERED_LIST, selStart, selEnd)
+            TextFormat.FORMAT_ORDERED_LIST -> return blockFormatter.containsList(TextFormat.FORMAT_ORDERED_LIST, selStart, selEnd)
+            TextFormat.FORMAT_QUOTE -> return blockFormatter.containQuote(selectionStart, selectionEnd)
+            TextFormat.FORMAT_LINK -> return linkFormatter.containLink(selStart, selEnd)
+            else -> return false
+        }
     }
 
     fun getAppliedHeading(selectionStart: Int, selectionEnd: Int): TextFormat? {
@@ -1232,130 +432,10 @@ class AztecText : EditText, TextWatcher {
         }
     }
 
-    fun getAppliedStyles(selectionStart: Int, selectionEnd: Int): ArrayList<TextFormat> {
-        val styles = ArrayList<TextFormat>()
-        TextFormat.values().forEach {
-            if (contains(it, selectionStart, selectionEnd)) {
-                styles.add(it)
-            }
-        }
-        return styles
-    }
-
-    fun isEmpty(): Boolean {
-        return text.isEmpty()
-    }
-
-    private fun formattingIsApplied(): Boolean {
-        return !selectedStyles.isEmpty()
-    }
-
-    private fun formattingHasChanged(): Boolean {
-        return isNewStyleSelected
-    }
-
-    private fun setFormattingChangesApplied() {
-        isNewStyleSelected = false
-    }
-
-    private fun clearInlineStyles(start: Int, end: Int, ignoreSelectedStyles: Boolean) {
-        getAppliedStyles(start, end).forEach {
-            if (!selectedStyles.contains(it) || ignoreSelectedStyles) {
-                when (it) {
-                    TextFormat.FORMAT_HEADING_1,
-                    TextFormat.FORMAT_HEADING_2,
-                    TextFormat.FORMAT_HEADING_3,
-                    TextFormat.FORMAT_HEADING_4,
-                    TextFormat.FORMAT_HEADING_5,
-                    TextFormat.FORMAT_HEADING_6 -> removeInlineStyle(it, start, end)
-                    TextFormat.FORMAT_BOLD -> removeInlineStyle(it, start, end)
-                    TextFormat.FORMAT_ITALIC -> removeInlineStyle(it, start, end)
-                    TextFormat.FORMAT_STRIKETHROUGH -> removeInlineStyle(it, start, end)
-                    else -> {
-                        //do nothing
-                    }
-                }
-            }
-        }
-    }
-
-    fun isTextSelected(): Boolean {
-        return selectionStart != selectionEnd
-    }
-
-    fun toggleFormatting(textFormat: TextFormat) {
-
-        history.beforeTextChanged(toFormattedHtml())
-
-        when (textFormat) {
-            TextFormat.FORMAT_PARAGRAPH -> heading(false, textFormat)
-            TextFormat.FORMAT_HEADING_1,
-            TextFormat.FORMAT_HEADING_2,
-            TextFormat.FORMAT_HEADING_3,
-            TextFormat.FORMAT_HEADING_4,
-            TextFormat.FORMAT_HEADING_5,
-            TextFormat.FORMAT_HEADING_6 -> heading(true, textFormat)
-            TextFormat.FORMAT_BOLD -> bold(!contains(TextFormat.FORMAT_BOLD))
-            TextFormat.FORMAT_ITALIC -> italic(!contains(TextFormat.FORMAT_ITALIC))
-            TextFormat.FORMAT_STRIKETHROUGH -> strikethrough(!contains(TextFormat.FORMAT_STRIKETHROUGH))
-            TextFormat.FORMAT_UNORDERED_LIST -> unorderedListValid(!contains(TextFormat.FORMAT_UNORDERED_LIST))
-            TextFormat.FORMAT_ORDERED_LIST -> orderedListValid(!contains(TextFormat.FORMAT_ORDERED_LIST))
-            TextFormat.FORMAT_QUOTE -> quote(!contains(TextFormat.FORMAT_QUOTE))
-            else -> {
-            }
-        }
-
-        history.handleHistory(this)
-    }
-
-    fun contains(format: TextFormat, selStart: Int = selectionStart, selEnd: Int = selectionEnd): Boolean {
-        when (format) {
-            TextFormat.FORMAT_HEADING_1,
-            TextFormat.FORMAT_HEADING_2,
-            TextFormat.FORMAT_HEADING_3,
-            TextFormat.FORMAT_HEADING_4,
-            TextFormat.FORMAT_HEADING_5,
-            TextFormat.FORMAT_HEADING_6 -> return containsHeading(format, selStart, selEnd)
-            TextFormat.FORMAT_BOLD -> return containsInlineStyle(TextFormat.FORMAT_BOLD, selStart, selEnd)
-            TextFormat.FORMAT_ITALIC -> return containsInlineStyle(TextFormat.FORMAT_ITALIC, selStart, selEnd)
-            TextFormat.FORMAT_UNDERLINED -> return containsInlineStyle(TextFormat.FORMAT_UNDERLINED, selStart, selEnd)
-            TextFormat.FORMAT_STRIKETHROUGH -> return containsInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selStart, selEnd)
-            TextFormat.FORMAT_UNORDERED_LIST -> return containsList(TextFormat.FORMAT_UNORDERED_LIST, selStart, selEnd)
-            TextFormat.FORMAT_ORDERED_LIST -> return containsList(TextFormat.FORMAT_ORDERED_LIST, selStart, selEnd)
-            TextFormat.FORMAT_QUOTE -> return containQuote(selectionStart, selectionEnd)
-            TextFormat.FORMAT_LINK -> return containLink(selStart, selEnd)
-            else -> return false
-        }
-    }
-
-
-    fun carryOverInlineSpans(start: Int, count: Int, after: Int) {
-        carryOverSpans.clear()
-
-        val charsAdded = after - count
-        if (charsAdded > 0 && count > 0) {
-            editableText.getSpans(start, start + count, AztecInlineSpan::class.java).forEach {
-                val spanStart = editableText.getSpanStart(it)
-                val spanEnd = editableText.getSpanEnd(it)
-
-
-                if ((spanStart == start || spanEnd == count + start) && spanEnd < after) {
-                    editableText.removeSpan(it)
-                    carryOverSpans.add(CarryOverSpan(it, spanStart, spanEnd))
-                }
-            }
-        }
-    }
-
-    fun reapplyCarriedOverInlineSpans() {
-        carryOverSpans?.forEach {
-            editableText.setSpan(it.span, it.start, it.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        }
-        carryOverSpans?.clear()
-    }
-
     override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
-        carryOverInlineSpans(start, count, after)
+        if (!isViewInitialized) return
+
+        inlineFormatter.carryOverInlineSpans(start, count, after)
 
         if (!isTextChangedListenerDisabled()) {
             history.beforeTextChanged(toFormattedHtml())
@@ -1363,7 +443,9 @@ class AztecText : EditText, TextWatcher {
     }
 
     override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
-        reapplyCarriedOverInlineSpans()
+        if (!isViewInitialized) return
+
+        inlineFormatter.reapplyCarriedOverInlineSpans()
         textChangedEventDetails = TextChangedEvent(text, start, before, count)
     }
 
@@ -1380,8 +462,8 @@ class AztecText : EditText, TextWatcher {
 
         history.handleHistory(this)
 
-        handleBlockStyling(text, textChangedEventDetails)
-        handleInlineStyling(text, textChangedEventDetails)
+        blockFormatter.handleBlockStyling(text, textChangedEventDetails)
+        inlineFormatter.handleInlineStyling(text, textChangedEventDetails)
     }
 
     fun removeLeadingStyle(text: Editable, spanClass: Class<*>) {
@@ -1394,167 +476,6 @@ class AztecText : EditText, TextWatcher {
         }
     }
 
-    fun handleInlineStyling(text: Editable, textChangedEvent: TextChangedEvent) {
-        //because we use SPAN_INCLUSIVE_INCLUSIVE for inline styles
-        //we need to make sure unselected styles are not applied
-        clearInlineStyles(textChangedEvent.inputStart, textChangedEvent.inputEnd, textChangedEvent.isNewLine())
-
-        //trailing styling
-        if (!formattingHasChanged() || textChangedEvent.isNewLine()) return
-
-        if (formattingIsApplied()) {
-            for (item in selectedStyles) {
-                when (item) {
-                    TextFormat.FORMAT_HEADING_1,
-                    TextFormat.FORMAT_HEADING_2,
-                    TextFormat.FORMAT_HEADING_3,
-                    TextFormat.FORMAT_HEADING_4,
-                    TextFormat.FORMAT_HEADING_5,
-                    TextFormat.FORMAT_HEADING_6 -> if (contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
-                        applyInlineStyle(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)
-                    }
-                    TextFormat.FORMAT_BOLD,
-                    TextFormat.FORMAT_ITALIC,
-                    TextFormat.FORMAT_STRIKETHROUGH -> if (!contains(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)) {
-                        applyInlineStyle(item, textChangedEvent.inputStart, textChangedEvent.inputEnd)
-                    }
-                    else -> {
-                        //do nothing
-                    }
-                }
-            }
-        }
-
-        setFormattingChangesApplied()
-    }
-
-    fun handleBlockStyling(text: Editable, textChangedEvent: TextChangedEvent) {
-        // preserve the attributes on the previous list item when adding a new one
-        if (textChangedEvent.isNewLine() && textChangedEvent.inputEnd < text.length && text[textChangedEvent.inputEnd] == '\n') {
-            val spans = text.getSpans(textChangedEvent.inputEnd, textChangedEvent.inputEnd + 1, AztecListItemSpan::class.java)
-            if (spans.size == 1) {
-                text.setSpan(spans[0], textChangedEvent.inputStart, textChangedEvent.inputEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
-        }
-        val inputStart = textChangedEvent.inputStart
-
-        val spanToClose = textChangedEvent.getBlockSpansToClose(text)
-        spanToClose.forEach {
-            var spanEnd = text.getSpanEnd(it)
-            var spanStart = text.getSpanStart(it)
-
-            if (spanEnd == spanStart) {
-                editableText.removeSpan(it)
-            } else if (spanEnd <= text.length) {
-                //case for when we remove block element row from first line of EditText end the next line is empty
-                if (inputStart == 0 && spanStart > 0 && text[spanStart] == '\n') {
-                    spanEnd += 1
-                    disableTextChangedListener()
-                    text.insert(spanStart, "\u200B")
-                } else
-                //case for when we remove block element row from other lines of EditText end the next line is empty
-                    if (text[spanStart] == '\n') {
-                        spanStart += 1
-
-                        if (text[spanStart] == '\n' && text.length >= spanEnd && text.length > spanStart) {
-                            spanEnd += 1
-                            disableTextChangedListener()
-                            text.insert(spanStart, "\u200B")
-                        }
-                    }
-
-                editableText.setSpan(it,
-                        spanStart,
-                        spanEnd,
-                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            }
-        }
-
-        val spanToOpen = textChangedEvent.getBlockSpanToOpen(text)
-        spanToOpen.forEach {
-            val textLength = text.length
-
-            var spanEnd = text.getSpanEnd(it)
-            val spanStart = text.getSpanStart(it)
-
-            if (inputStart < spanStart) {
-                editableText.setSpan(it,
-                        inputStart,
-                        spanEnd,
-                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            } else {
-                val indexOfLineEnd = text.indexOf('\n', spanEnd - 1, true)
-
-                if (indexOfLineEnd == spanEnd) {
-                    spanEnd += textChangedEvent.count
-                } else if (indexOfLineEnd == -1) {
-                    spanEnd = text.length
-                } else {
-                    spanEnd = indexOfLineEnd
-                }
-
-                if (spanEnd <= textLength) {
-                    editableText.setSpan(it,
-                            text.getSpanStart(it),
-                            spanEnd,
-                            Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
-                }
-            }
-        }
-
-        if (textChangedEvent.isAfterZeroWidthJoiner() && !textChangedEvent.isNewLine()) {
-            disableTextChangedListener()
-            text.delete(inputStart - 1, inputStart)
-        } else if (textChangedEvent.isAfterZeroWidthJoiner() && textChangedEvent.isNewLine()) {
-            removeBlockStyle()
-            disableTextChangedListener()
-
-            if (inputStart == 1) {
-                text.delete(inputStart - 1, inputStart + 1)
-            } else {
-                text.delete(inputStart - 2, inputStart)
-            }
-
-        } else if (!textChangedEvent.isAfterZeroWidthJoiner() && textChangedEvent.isNewLine()) {
-            //Add ZWJ to the new line at the end of block spans
-            val blockSpans = getText().getSpans(inputStart, inputStart, AztecBlockSpan::class.java)
-            if (!blockSpans.isEmpty() && text.getSpanEnd(blockSpans[0]) == inputStart + 1) {
-                disableTextChangedListener()
-                text.insert(inputStart + 1, "\u200B")
-            }
-        }
-
-
-    }
-
-    fun getSelectedTextBounds(editable: Editable, selectionStart: Int, selectionEnd: Int): IntRange {
-        val startOfLine: Int
-        val endOfLine: Int
-
-        val indexOfFirstLineBreak: Int
-        val indexOfLastLineBreak = editable.indexOf("\n", selectionEnd)
-
-        if (indexOfLastLineBreak > 0) {
-            val characterBeforeLastLineBreak = editable[indexOfLastLineBreak - 1]
-            if (characterBeforeLastLineBreak != '\n') {
-                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart - 1) + 1
-            } else {
-                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart)
-            }
-        } else {
-            if (indexOfLastLineBreak == -1) {
-                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart) + 1
-            } else {
-                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart)
-            }
-        }
-
-
-        startOfLine = if (indexOfFirstLineBreak != -1) indexOfFirstLineBreak else 0
-        endOfLine = if (indexOfLastLineBreak != -1) indexOfLastLineBreak else editable.length
-
-        return IntRange(startOfLine, endOfLine)
-    }
 
     fun redo() {
         history.redo(this)
@@ -1565,23 +486,6 @@ class AztecText : EditText, TextWatcher {
     }
 
 // Helper ======================================================================================
-
-    fun clearFormats() {
-        setText(editableText.toString())
-        setSelection(editableText.length)
-    }
-
-    fun hideSoftInput() {
-        clearFocus()
-        val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(windowToken, 0)
-    }
-
-    fun showSoftInput() {
-        requestFocus()
-        val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0)
-    }
 
     fun consumeCursorPosition(text: SpannableStringBuilder): Int {
         var cursorPosition = 0
@@ -1633,7 +537,7 @@ class AztecText : EditText, TextWatcher {
             val spanStart = editable.getSpanStart(it)
             val spanEnd = editable.getSpanEnd(it)
             editable.removeSpan(it)
-            editable.setSpan(makeBlockSpan(it.javaClass, it.attributes), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            editable.setSpan(blockFormatter.makeBlockSpan(it.javaClass, it.attributes), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
 
         val paragraphSpans = editable.getSpans(start, end, ParagraphSpan::class.java)
@@ -1676,11 +580,7 @@ class AztecText : EditText, TextWatcher {
         enableTextChangedListener()
     }
 
-    private fun removeBlockStylesFromRange(start: Int, end: Int, ignoreLineBounds: Boolean = false) {
-        removeBlockStyle(start, end, AztecBlockSpan::class.java, ignoreLineBounds)
-    }
-
-    private fun removeHeadingStylesFromRange(start: Int, end: Int) {
+    fun removeHeadingStylesFromRange(start: Int, end: Int) {
         val spans = editableText.getSpans(start, end, AztecHeadingSpan::class.java)
 
         for (span in spans) {
@@ -1689,10 +589,15 @@ class AztecText : EditText, TextWatcher {
     }
 
     fun removeInlineStylesFromRange(start: Int, end: Int) {
-        removeInlineStyle(TextFormat.FORMAT_BOLD, start, end)
-        removeInlineStyle(TextFormat.FORMAT_ITALIC, start, end)
-        removeInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, start, end)
-        removeInlineStyle(TextFormat.FORMAT_UNDERLINED, start, end)
+        inlineFormatter.removeInlineStyle(TextFormat.FORMAT_BOLD, start, end)
+        inlineFormatter.removeInlineStyle(TextFormat.FORMAT_ITALIC, start, end)
+        inlineFormatter.removeInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, start, end)
+        inlineFormatter.removeInlineStyle(TextFormat.FORMAT_UNDERLINED, start, end)
+    }
+
+
+    fun removeBlockStylesFromRange(start: Int, end: Int, ignoreLineBounds: Boolean = false) {
+        blockFormatter.removeBlockStyle(start, end, AztecBlockSpan::class.java, ignoreLineBounds)
     }
 
     //logic party copied from TextView
@@ -1754,7 +659,7 @@ class AztecText : EditText, TextWatcher {
                 editable.replace(min, max, builder)
                 enableTextChangedListener()
 
-                joinStyleSpans(0, editable.length) //TODO: see how this affects performance
+                inlineFormatter.joinStyleSpans(0, editable.length) //TODO: see how this affects performance
             }
         }
     }
@@ -1770,5 +675,64 @@ class AztecText : EditText, TextWatcher {
         if (visibility == View.VISIBLE) {
             requestFocus()
         }
+    }
+
+    fun link(url: String, anchor: String) {
+        if (TextUtils.isEmpty(url) && linkFormatter.isUrlSelected()) {
+            removeLink()
+        } else if (linkFormatter.isUrlSelected()) {
+            linkFormatter.editLink(url, anchor, linkFormatter.getUrlSpanBounds().first, linkFormatter.getUrlSpanBounds().second)
+        } else {
+            linkFormatter.addLink(url, anchor, selectionStart, selectionEnd)
+        }
+    }
+
+
+    fun removeLink() {
+        val urlSpanBounds = linkFormatter.getUrlSpanBounds()
+
+        linkFormatter.linkInvalid(urlSpanBounds.first, urlSpanBounds.second)
+        onSelectionChanged(urlSpanBounds.first, urlSpanBounds.second)
+    }
+
+    fun showLinkDialog(presetUrl: String = "", presetAnchor: String = "") {
+        val urlAndAnchor = linkFormatter.getSelectedUrlWithAnchor()
+
+        val url = if (TextUtils.isEmpty(presetUrl)) urlAndAnchor.first else presetUrl
+        val anchor = if (TextUtils.isEmpty(presetAnchor)) urlAndAnchor.second else presetAnchor
+
+        val builder = AlertDialog.Builder(context)
+
+        val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_link, null, false)
+
+        val urlInput = dialogView.findViewById(R.id.linkURL) as EditText
+        val anchorInput = dialogView.findViewById(R.id.linkText) as EditText
+
+        urlInput.setText(url)
+        anchorInput.setText(anchor)
+
+        builder.setView(dialogView)
+        builder.setTitle(R.string.dialog_title)
+
+        builder.setPositiveButton(R.string.dialog_button_ok, { dialog, which ->
+            val linkText = urlInput.text.toString().trim { it <= ' ' }
+            val anchorText = anchorInput.text.toString().trim { it <= ' ' }
+
+            link(linkText, anchorText)
+
+        })
+
+        if (linkFormatter.isUrlSelected()) {
+            builder.setNeutralButton(R.string.dialog_button_remove_link, { dialogInterface, i ->
+                removeLink()
+            })
+        }
+
+        builder.setNegativeButton(R.string.dialog_button_cancel, { dialogInterface, i ->
+            dialogInterface.dismiss()
+        })
+
+        addLinkDialog = builder.create()
+        addLinkDialog!!.show()
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -245,92 +245,6 @@ class AztecText : EditText, TextWatcher {
         setSelectedStyles(getAppliedStyles(if (selStart > 0 && !isTextSelected()) selStart - 1 else selStart, selEnd))
     }
 
-    // Inline Styles ===================================================================================
-
-    private fun bold(valid: Boolean) {
-        if (valid) {
-            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_BOLD, selectionStart, selectionEnd)
-        } else {
-            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_BOLD, selectionStart, selectionEnd)
-        }
-    }
-
-    private fun italic(valid: Boolean) {
-        if (valid) {
-            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_ITALIC, selectionStart, selectionEnd)
-        } else {
-            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_ITALIC, selectionStart, selectionEnd)
-        }
-    }
-
-    fun underline(valid: Boolean) {
-        if (valid) {
-            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_UNDERLINED, selectionStart, selectionEnd)
-        } else {
-            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_UNDERLINED, selectionEnd, selectionEnd)
-        }
-    }
-
-    fun strikethrough(valid: Boolean) {
-        if (valid) {
-            inlineFormatter.applyInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selectionStart, selectionEnd)
-        } else {
-            inlineFormatter.removeInlineStyle(TextFormat.FORMAT_STRIKETHROUGH, selectionStart, selectionEnd)
-        }
-    }
-
-
-    // HeadingSpan =================================================================================
-
-    fun heading(format: Boolean, textFormat: TextFormat) {
-        lineBlockFormatter.headingClear()
-
-        if (format) {
-            lineBlockFormatter.headingFormat(textFormat)
-        }
-    }
-
-
-    // BulletSpan ==================================================================================
-
-    fun orderedList(valid: Boolean) {
-        if (valid) {
-            if (blockFormatter.containsList(TextFormat.FORMAT_UNORDERED_LIST, selectionStart, selectionEnd)) {
-                blockFormatter.switchListType(TextFormat.FORMAT_ORDERED_LIST)
-            } else {
-                blockFormatter.applyBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
-            }
-        } else {
-            blockFormatter.removeBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
-        }
-    }
-
-    fun unorderedList(valid: Boolean) {
-        if (valid) {
-            if (blockFormatter.containsList(TextFormat.FORMAT_ORDERED_LIST, selectionStart, selectionEnd)) {
-                blockFormatter.switchListType(TextFormat.FORMAT_UNORDERED_LIST)
-            } else {
-                blockFormatter.applyBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
-            }
-        } else {
-            blockFormatter.removeBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
-        }
-    }
-
-
-
-
-    // QuoteSpan ===================================================================================
-
-    fun quote(valid: Boolean) {
-        if (valid) {
-            blockFormatter.applyBlockStyle(TextFormat.FORMAT_QUOTE)
-        } else {
-            blockFormatter.removeBlockStyle(TextFormat.FORMAT_QUOTE)
-        }
-    }
-
-
     fun getSelectedText(): String {
         if (selectionStart == -1 || selectionEnd == -1) return ""
         return editableText.substring(selectionStart, selectionEnd)
@@ -372,19 +286,19 @@ class AztecText : EditText, TextWatcher {
         history.beforeTextChanged(toFormattedHtml())
 
         when (textFormat) {
-            TextFormat.FORMAT_PARAGRAPH -> heading(false, textFormat)
+            TextFormat.FORMAT_PARAGRAPH,
             TextFormat.FORMAT_HEADING_1,
             TextFormat.FORMAT_HEADING_2,
             TextFormat.FORMAT_HEADING_3,
             TextFormat.FORMAT_HEADING_4,
             TextFormat.FORMAT_HEADING_5,
-            TextFormat.FORMAT_HEADING_6 -> heading(true, textFormat)
-            TextFormat.FORMAT_BOLD -> bold(!contains(TextFormat.FORMAT_BOLD))
-            TextFormat.FORMAT_ITALIC -> italic(!contains(TextFormat.FORMAT_ITALIC))
-            TextFormat.FORMAT_STRIKETHROUGH -> strikethrough(!contains(TextFormat.FORMAT_STRIKETHROUGH))
-            TextFormat.FORMAT_UNORDERED_LIST -> unorderedList(!contains(TextFormat.FORMAT_UNORDERED_LIST))
-            TextFormat.FORMAT_ORDERED_LIST -> orderedList(!contains(TextFormat.FORMAT_ORDERED_LIST))
-            TextFormat.FORMAT_QUOTE -> quote(!contains(TextFormat.FORMAT_QUOTE))
+            TextFormat.FORMAT_HEADING_6 -> lineBlockFormatter.applyHeading(textFormat)
+            TextFormat.FORMAT_BOLD -> inlineFormatter.toggleBold()
+            TextFormat.FORMAT_ITALIC -> inlineFormatter.toggleItalic()
+            TextFormat.FORMAT_STRIKETHROUGH -> inlineFormatter.toggleStrikethrough()
+            TextFormat.FORMAT_UNORDERED_LIST -> blockFormatter.toggleUnorderedList()
+            TextFormat.FORMAT_ORDERED_LIST -> blockFormatter.toggleOrderedList()
+            TextFormat.FORMAT_QUOTE -> blockFormatter.toggleQuote()
             TextFormat.FORMAT_MORE -> lineBlockFormatter.applyComment(AztecCommentSpan.Comment.MORE)
             TextFormat.FORMAT_PAGE -> lineBlockFormatter.applyComment(AztecCommentSpan.Comment.PAGE)
             else -> {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -366,7 +366,7 @@ class AztecText : EditText, TextWatcher {
         history.handleHistory(this)
 
         blockFormatter.handleBlockStyling(text, textChangedEventDetails)
-        inlineFormatter.handleInlineStyling(text, textChangedEventDetails)
+        inlineFormatter.handleInlineStyling(textChangedEventDetails)
     }
 
     fun removeLeadingStyle(text: Editable, spanClass: Class<*>) {
@@ -605,7 +605,7 @@ class AztecText : EditText, TextWatcher {
 
         val builder = AlertDialog.Builder(context)
 
-        val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_link, null, false)
+        val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_link, null)
 
         val urlInput = dialogView.findViewById(R.id.linkURL) as EditText
         val anchorInput = dialogView.findViewById(R.id.linkText) as EditText

--- a/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/TextChangedEvent.kt
@@ -1,10 +1,5 @@
 package org.wordpress.aztec
 
-import android.text.Editable
-import android.text.Spanned
-import org.wordpress.aztec.spans.AztecBlockSpan
-import java.util.*
-
 
 data class TextChangedEvent(val text: CharSequence, val start: Int, val before: Int, val countOfCharacters: Int) {
 
@@ -44,85 +39,6 @@ data class TextChangedEvent(val text: CharSequence, val start: Int, val before: 
 
         return false
     }
-
-    fun getBlockSpanToOpen(editableText: Editable): ArrayList<AztecBlockSpan> {
-
-        val spansToClose = ArrayList<AztecBlockSpan>()
-        if (count >= 0) {
-            if (text.length > inputStart)  {
-                val spans = editableText.getSpans(inputStart, inputStart, AztecBlockSpan::class.java)
-
-                spans.forEach {
-                    val previousCharacter = if (isAddingCharacters) text[inputStart - 1] else text[inputEnd]
-                    if (previousCharacter == '\n') return@forEach
-
-                    val deletingLastCharacter = !isAddingCharacters && text.length == inputEnd
-                    if (deletingLastCharacter) return@forEach
-
-                    if (!isAddingCharacters && text.length > inputEnd) {
-                        val lastCharacter = text[inputEnd]
-                        if (lastCharacter == '\n') return@forEach
-                    }
-
-
-                    val flags = editableText.getSpanFlags(spans[0])
-                    if ((flags and Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) == Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) {
-                        spansToClose.add(it)
-                    }
-                }
-
-                if (spans.isEmpty()) {
-                    val spansAfterInput = editableText.getSpans(inputEnd, inputEnd, AztecBlockSpan::class.java)
-                    spansAfterInput.forEach {
-                        val flags = editableText.getSpanFlags(spansAfterInput[0])
-                        if (((flags and Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) == Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) ||
-                                (flags and Spanned.SPAN_EXCLUSIVE_INCLUSIVE) == Spanned.SPAN_EXCLUSIVE_INCLUSIVE) {
-                            spansToClose.add(it)
-                        }
-                    }
-                }
-            }
-        }
-
-        return spansToClose
-
-    }
-
-    fun getBlockSpansToClose(editableText: Editable): ArrayList<AztecBlockSpan> {
-        val spansToClose = ArrayList<AztecBlockSpan>()
-
-        val startIndex = if (isAddingCharacters) inputStart else inputEnd
-        if (startIndex > 0 && count == 1) {
-            if (text[startIndex - 1] != '\n') return spansToClose
-
-            val spans = editableText.getSpans(startIndex, startIndex, AztecBlockSpan::class.java)
-            spans.forEach {
-                val spanStart = editableText.getSpanStart(spans[0])
-                val spanEnd = editableText.getSpanEnd(spans[0])
-
-                if (startIndex == spanStart) {
-                    spansToClose.add(it)
-                } else if (startIndex == spanEnd) {
-                    val flags = editableText.getSpanFlags(spans[0])
-                    if ((flags and Spanned.SPAN_EXCLUSIVE_INCLUSIVE) == Spanned.SPAN_EXCLUSIVE_INCLUSIVE) {
-                        spansToClose.add(it)
-                    }
-                }
-
-            }
-
-
-        } else if (startIndex == 0 && count == 1 && text.length > 0) {
-            val spansAfterInput = editableText.getSpans(startIndex + 1, startIndex + 1, AztecBlockSpan::class.java)
-            spansAfterInput.forEach {
-                spansToClose.add(it)
-            }
-        }
-
-        return spansToClose
-
-    }
-
 
 }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/AztecFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/AztecFormatter.kt
@@ -1,0 +1,24 @@
+package org.wordpress.aztec.formatting
+
+import android.text.Editable
+import org.wordpress.aztec.AztecText
+
+
+abstract class AztecFormatter(editor: AztecText) {
+
+    val editor: AztecText
+
+    val selectionStart: Int
+        get() = this.editor.selectionStart
+
+    val selectionEnd: Int
+        get() = this.editor.selectionEnd
+
+    val editableText: Editable
+        get() = this.editor.editableText
+
+    init {
+        this.editor = editor
+    }
+
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -1,0 +1,418 @@
+package org.wordpress.aztec.formatting
+
+import android.text.Editable
+import android.text.Spanned
+import android.text.TextUtils
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.TextChangedEvent
+import org.wordpress.aztec.TextFormat
+import org.wordpress.aztec.spans.*
+import java.util.*
+
+
+class BlockFormatter(editor: AztecText) {
+
+    val editor: AztecText
+
+    init {
+        this.editor = editor
+    }
+
+    fun orderedList(){
+
+    }
+
+    fun handleBlockStyling(text: Editable, textChangedEvent: TextChangedEvent) {
+        // preserve the attributes on the previous list item when adding a new one
+        if (textChangedEvent.isNewLine() && textChangedEvent.inputEnd < text.length && text[textChangedEvent.inputEnd] == '\n') {
+            val spans = text.getSpans(textChangedEvent.inputEnd, textChangedEvent.inputEnd + 1, AztecListItemSpan::class.java)
+            if (spans.size == 1) {
+                text.setSpan(spans[0], textChangedEvent.inputStart, textChangedEvent.inputEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+        }
+        val inputStart = textChangedEvent.inputStart
+
+        val spanToClose = textChangedEvent.getBlockSpansToClose(text)
+        spanToClose.forEach {
+            var spanEnd = text.getSpanEnd(it)
+            var spanStart = text.getSpanStart(it)
+
+            if (spanEnd == spanStart) {
+                editor.editableText.removeSpan(it)
+            } else if (spanEnd <= text.length) {
+                //case for when we remove block element row from first line of EditText end the next line is empty
+                if (inputStart == 0 && spanStart > 0 && text[spanStart] == '\n') {
+                    spanEnd += 1
+                    editor.disableTextChangedListener()
+                    text.insert(spanStart, "\u200B")
+                } else
+                //case for when we remove block element row from other lines of EditText end the next line is empty
+                    if (text[spanStart] == '\n') {
+                        spanStart += 1
+
+                        if (text[spanStart] == '\n' && text.length >= spanEnd && text.length > spanStart) {
+                            spanEnd += 1
+                            editor.disableTextChangedListener()
+                            text.insert(spanStart, "\u200B")
+                        }
+                    }
+
+                editor.editableText.setSpan(it,
+                        spanStart,
+                        spanEnd,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+        }
+
+        val spanToOpen = textChangedEvent.getBlockSpanToOpen(text)
+        spanToOpen.forEach {
+            val textLength = text.length
+
+            var spanEnd = text.getSpanEnd(it)
+            val spanStart = text.getSpanStart(it)
+
+            if (inputStart < spanStart) {
+                editor.editableText.setSpan(it,
+                        inputStart,
+                        spanEnd,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            } else {
+                val indexOfLineEnd = text.indexOf('\n', spanEnd - 1, true)
+
+                if (indexOfLineEnd == spanEnd) {
+                    spanEnd += textChangedEvent.count
+                } else if (indexOfLineEnd == -1) {
+                    spanEnd = text.length
+                } else {
+                    spanEnd = indexOfLineEnd
+                }
+
+                if (spanEnd <= textLength) {
+                    editor.editableText.setSpan(it,
+                            text.getSpanStart(it),
+                            spanEnd,
+                            Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+                }
+            }
+        }
+
+        if (textChangedEvent.isAfterZeroWidthJoiner() && !textChangedEvent.isNewLine()) {
+            editor.disableTextChangedListener()
+            text.delete(inputStart - 1, inputStart)
+        } else if (textChangedEvent.isAfterZeroWidthJoiner() && textChangedEvent.isNewLine()) {
+            removeBlockStyle()
+            editor.disableTextChangedListener()
+
+            if (inputStart == 1) {
+                text.delete(inputStart - 1, inputStart + 1)
+            } else {
+                text.delete(inputStart - 2, inputStart)
+            }
+
+        } else if (!textChangedEvent.isAfterZeroWidthJoiner() && textChangedEvent.isNewLine()) {
+            //Add ZWJ to the new line at the end of block spans
+            val blockSpans = editor.editableText.getSpans(inputStart, inputStart, AztecBlockSpan::class.java)
+            if (!blockSpans.isEmpty() && text.getSpanEnd(blockSpans[0]) == inputStart + 1) {
+                editor.disableTextChangedListener()
+                text.insert(inputStart + 1, "\u200B")
+            }
+        }
+    }
+
+    fun removeBlockStyle(textFormat: TextFormat) {
+        removeBlockStyle(editor.selectionStart, editor.selectionEnd, makeBlockSpan(textFormat).javaClass)
+    }
+
+    fun removeBlockStyle(start: Int = editor.selectionStart, end: Int = editor.selectionEnd,
+                         spanType: Class<AztecBlockSpan> = AztecBlockSpan::class.java, ignoreLineBounds: Boolean = false) {
+        val spans = editor.editableText.getSpans(start, end, spanType)
+        spans.forEach {
+
+            val spanStart = editor.editableText.getSpanStart(it)
+            var spanEnd = editor.editableText.getSpanEnd(it)
+
+            //if splitting block set a range that would be excluded from it
+            val boundsOfSelectedText = if (ignoreLineBounds) IntRange(start, end) else getSelectedTextBounds(editor.editableText, start, end)
+
+            val startOfLine = boundsOfSelectedText.start
+            val endOfLine = boundsOfSelectedText.endInclusive
+
+            val spanPrecedesLine = spanStart < startOfLine
+            val spanExtendsBeyondLine = endOfLine < spanEnd
+
+            //remove the span from all the selected lines
+            editor.editableText.removeSpan(it)
+
+
+            //reapply span top "top" and "bottom"
+            if (spanPrecedesLine) {
+                editor.editableText.setSpan(makeBlockSpan(it.javaClass), spanStart, startOfLine - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+
+            if (spanExtendsBeyondLine) {
+                if (editor.editableText[endOfLine] == '\n' && !ignoreLineBounds) {
+                    editor.disableTextChangedListener()
+                    editor.editableText.delete(endOfLine, endOfLine + 1)
+                    spanEnd--
+                }
+
+                editor.editableText.setSpan(makeBlockSpan(it.javaClass), endOfLine, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+
+        }
+    }
+
+
+    //TODO: Come up with a better way to init spans and get their classes (all the "make" methods)
+    fun makeBlockSpan(textFormat: TextFormat, attrs: String? = null): AztecBlockSpan {
+        when (textFormat) {
+            TextFormat.FORMAT_ORDERED_LIST -> return AztecOrderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
+            TextFormat.FORMAT_UNORDERED_LIST -> return AztecUnorderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
+            TextFormat.FORMAT_QUOTE -> return AztecQuoteSpan(editor.quoteBackground, editor.quoteColor, editor.quoteMargin, editor.quoteWidth, editor.quotePadding, attrs)
+            else -> return ParagraphSpan(attrs)
+        }
+    }
+
+
+    fun makeBlockSpan(spanType: Class<AztecBlockSpan>, attrs: String? = null): AztecBlockSpan {
+        when (spanType) {
+            AztecOrderedListSpan::class.java -> return AztecOrderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
+            AztecUnorderedListSpan::class.java -> return AztecUnorderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
+            AztecQuoteSpan::class.java -> return AztecQuoteSpan(editor.quoteBackground, editor.quoteColor, editor.quoteMargin, editor.quoteWidth, editor.quotePadding, attrs)
+            else -> return ParagraphSpan(attrs)
+        }
+    }
+
+
+    fun getSelectedTextBounds(editable: Editable, selectionStart: Int, selectionEnd: Int): IntRange {
+        val startOfLine: Int
+        val endOfLine: Int
+
+        val indexOfFirstLineBreak: Int
+        val indexOfLastLineBreak = editable.indexOf("\n", selectionEnd)
+
+        if (indexOfLastLineBreak > 0) {
+            val characterBeforeLastLineBreak = editable[indexOfLastLineBreak - 1]
+            if (characterBeforeLastLineBreak != '\n') {
+                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart - 1) + 1
+            } else {
+                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart)
+            }
+        } else {
+            if (indexOfLastLineBreak == -1) {
+                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart) + 1
+            } else {
+                indexOfFirstLineBreak = editable.lastIndexOf("\n", selectionStart)
+            }
+        }
+
+
+        startOfLine = if (indexOfFirstLineBreak != -1) indexOfFirstLineBreak else 0
+        endOfLine = if (indexOfLastLineBreak != -1) indexOfLastLineBreak else editable.length
+
+        return IntRange(startOfLine, endOfLine)
+    }
+
+
+    fun applyBlockStyle(blockElementType: TextFormat, start: Int = editor.selectionStart, end: Int = editor.selectionEnd) {
+        if (start != end) {
+            val selectedText = editor.editableText.substring(start + 1..end - 1)
+
+            //multiline text selected
+            if (selectedText.indexOf("\n") != -1) {
+                val indexOfFirstLineBreak = editor.editableText.indexOf("\n", end)
+
+                val endOfBlock = if (indexOfFirstLineBreak != -1) indexOfFirstLineBreak else editor.editableText.length
+                val startOfBlock = editor.editableText.lastIndexOf("\n", start)
+
+                val selectedLines = editor.editableText.subSequence(startOfBlock + 1..endOfBlock - 1) as Editable
+
+                var numberOfLinesWithSpanApplied = 0
+                var numberOfLines = 0
+
+                val lines = TextUtils.split(selectedLines.toString(), "\n")
+
+                for (i in lines.indices) {
+                    numberOfLines++
+                    if (containsList(blockElementType, i, selectedLines)) {
+                        numberOfLinesWithSpanApplied++
+                    }
+                }
+
+                if (numberOfLines == numberOfLinesWithSpanApplied) {
+                    removeBlockStyle(blockElementType)
+                } else {
+                    editor.editableText.setSpan(makeBlockSpan(blockElementType), startOfBlock + 1, endOfBlock, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+                }
+            }
+
+        } else {
+            val boundsOfSelectedText = getSelectedTextBounds(editor.editableText, start, end)
+
+            val startOfLine = boundsOfSelectedText.start
+            var endOfLine = boundsOfSelectedText.endInclusive
+
+            val isEmptyLine = startOfLine == endOfLine
+
+            if (isEmptyLine) {
+                editor.disableTextChangedListener()
+                editor.editableText.insert(startOfLine, "\u200B")
+                endOfLine += 1
+            }
+
+            val spanToApply = makeBlockSpan(blockElementType)
+
+            var startOfBlock: Int = startOfLine
+            var endOfBlock: Int = endOfLine
+
+
+            if (startOfLine != 0) {
+                val spansOnPreviousLine = editor.editableText.getSpans(startOfLine - 1, startOfLine - 1, spanToApply.javaClass)
+                if (!spansOnPreviousLine.isEmpty()) {
+                    startOfBlock = editor.editableText.getSpanStart(spansOnPreviousLine[0])
+                    editor.editableText.removeSpan(spansOnPreviousLine[0])
+                }
+            }
+
+            if (endOfLine != editor.editableText.length) {
+                val spanOnNextLine = editor.editableText.getSpans(endOfLine + 1, endOfLine + 1, spanToApply.javaClass)
+                if (!spanOnNextLine.isEmpty()) {
+                    endOfBlock = editor.editableText.getSpanEnd(spanOnNextLine[0])
+                    editor.editableText.removeSpan(spanOnNextLine[0])
+                }
+            }
+
+            editor.editableText.setSpan(spanToApply, startOfBlock, endOfBlock, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+
+            //if the line was empty trigger onSelectionChanged manually to update toolbar buttons status
+            if (isEmptyLine) {
+                editor.onSelectionChanged(startOfLine, endOfLine)
+            }
+        }
+    }
+
+
+    fun containsList(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+        val list = ArrayList<Int>()
+
+
+        for (i in lines.indices) {
+            var lineStart = 0
+            for (j in 0..i - 1) {
+                lineStart += lines[j].length + 1
+            }
+
+            val lineEnd = lineStart + lines[i].length
+            if (lineStart > lineEnd) {
+                continue
+            }
+
+            if (lineStart <= selStart && selEnd <= lineEnd) {
+                list.add(i)
+            } else if (selStart <= lineStart && lineEnd <= selEnd) {
+                list.add(i)
+            }
+        }
+
+        if (list.isEmpty()) return false
+
+        for (i in list) {
+            if (!containsList(textFormat, i)) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    fun containsList(textFormat: TextFormat, index: Int, text: Editable = editor.editableText): Boolean {
+        val lines = TextUtils.split(text.toString(), "\n")
+        if (index < 0 || index >= lines.size) {
+            return false
+        }
+
+        var start = 0
+        for (i in 0..index - 1) {
+            start += lines[i].length + 1
+        }
+
+        val end = start + lines[index].length
+        if (start > end) {
+            return false
+        }
+
+        val spans = editor.editableText.getSpans(start, end, makeBlockSpan(textFormat).javaClass)
+        return spans.size > 0
+    }
+
+
+    fun containQuote(selStart: Int, selEnd: Int): Boolean {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+        val list = ArrayList<Int>()
+
+        for (i in lines.indices) {
+            var lineStart = 0
+            for (j in 0..i - 1) {
+                lineStart += lines[j].length + 1
+            }
+
+            val lineEnd = lineStart + lines[i].length
+            if (lineStart >= lineEnd) {
+                continue
+            }
+
+            if (lineStart <= selStart && selEnd <= lineEnd) {
+                list.add(i)
+            } else if (selStart <= lineStart && lineEnd <= selEnd) {
+                list.add(i)
+            }
+        }
+
+        if (list.isEmpty()) return false
+
+        for (i in list) {
+            if (!containQuote(i)) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    fun containQuote(index: Int): Boolean {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+        if (index < 0 || index >= lines.size) {
+            return false
+        }
+
+        var start = 0
+        for (i in 0..index - 1) {
+            start += lines[i].length + 1
+        }
+
+        val end = start + lines[index].length
+        if (start >= end) {
+            return false
+        }
+
+        val spans = editor.editableText.getSpans(start, end, AztecQuoteSpan::class.java)
+        return spans.size > 0
+    }
+
+    fun switchListType(listTypeToSwitchTo: TextFormat, start: Int = editor.selectionStart, end: Int = editor.selectionEnd) {
+        val spans = editor.editableText.getSpans(start, end, AztecListSpan::class.java)
+
+        if (spans.isEmpty()) return
+
+        val existingListSpan = spans[0]
+
+        val spanStart = editor.editableText.getSpanStart(existingListSpan)
+        val spanEnd = editor.editableText.getSpanEnd(existingListSpan)
+        val spanFlags = editor.editableText.getSpanFlags(existingListSpan)
+        editor.editableText.removeSpan(existingListSpan)
+
+        editor.editableText.setSpan(makeBlockSpan(listTypeToSwitchTo), spanStart, spanEnd, spanFlags)
+        editor.onSelectionChanged(start, end)
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -18,8 +18,36 @@ class BlockFormatter(editor: AztecText) {
         this.editor = editor
     }
 
-    fun orderedList(){
+    fun toggleOrderedList() {
+        if (!containsList(TextFormat.FORMAT_ORDERED_LIST)) {
+            if (containsList(TextFormat.FORMAT_UNORDERED_LIST)) {
+                switchListType(TextFormat.FORMAT_ORDERED_LIST)
+            } else {
+                applyBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
+            }
+        } else {
+            removeBlockStyle(TextFormat.FORMAT_ORDERED_LIST)
+        }
+    }
 
+    fun toggleUnorderedList() {
+        if (!containsList(TextFormat.FORMAT_UNORDERED_LIST)) {
+            if (containsList(TextFormat.FORMAT_ORDERED_LIST)) {
+                switchListType(TextFormat.FORMAT_UNORDERED_LIST)
+            } else {
+                applyBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
+            }
+        } else {
+            removeBlockStyle(TextFormat.FORMAT_UNORDERED_LIST)
+        }
+    }
+
+    fun toggleQuote() {
+        if (!containQuote()) {
+            applyBlockStyle(TextFormat.FORMAT_QUOTE)
+        } else {
+            removeBlockStyle(TextFormat.FORMAT_QUOTE)
+        }
     }
 
     fun handleBlockStyling(text: Editable, textChangedEvent: TextChangedEvent) {
@@ -292,7 +320,7 @@ class BlockFormatter(editor: AztecText) {
     }
 
 
-    fun containsList(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
+    fun containsList(textFormat: TextFormat, selStart: Int = editor.selectionStart, selEnd: Int = editor.selectionEnd): Boolean {
         val lines = TextUtils.split(editor.editableText.toString(), "\n")
         val list = ArrayList<Int>()
 
@@ -318,7 +346,7 @@ class BlockFormatter(editor: AztecText) {
         if (list.isEmpty()) return false
 
         for (i in list) {
-            if (!containsList(textFormat, i)) {
+            if (!containsList(textFormat, i, editor.editableText)) {
                 return false
             }
         }
@@ -326,7 +354,7 @@ class BlockFormatter(editor: AztecText) {
         return true
     }
 
-    fun containsList(textFormat: TextFormat, index: Int, text: Editable = editor.editableText): Boolean {
+    fun containsList(textFormat: TextFormat, index: Int, text: Editable): Boolean {
         val lines = TextUtils.split(text.toString(), "\n")
         if (index < 0 || index >= lines.size) {
             return false
@@ -347,7 +375,7 @@ class BlockFormatter(editor: AztecText) {
     }
 
 
-    fun containQuote(selStart: Int, selEnd: Int): Boolean {
+    fun containQuote(selStart: Int = editor.selectionStart, selEnd: Int = editor.selectionEnd): Boolean {
         val lines = TextUtils.split(editor.editableText.toString(), "\n")
         val list = ArrayList<Int>()
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -10,12 +10,19 @@ import org.wordpress.aztec.spans.*
 import java.util.*
 
 
-class BlockFormatter(editor: AztecText) {
+class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteStyle) {
+
+    data class ListStyle(val indicatorColor: Int, val indicatorMargin: Int, val indicatorPadding: Int, val indicatorWidth: Int)
+    data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int)
 
     val editor: AztecText
+    val listStyle: ListStyle
+    val quoteStyle: QuoteStyle
 
     init {
         this.editor = editor
+        this.listStyle = listStyle
+        this.quoteStyle = quoteStyle
     }
 
     fun toggleOrderedList() {
@@ -186,7 +193,6 @@ class BlockFormatter(editor: AztecText) {
 
                 editor.editableText.setSpan(makeBlockSpan(it.javaClass), endOfLine, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
-
         }
     }
 
@@ -194,9 +200,9 @@ class BlockFormatter(editor: AztecText) {
     //TODO: Come up with a better way to init spans and get their classes (all the "make" methods)
     fun makeBlockSpan(textFormat: TextFormat, attrs: String? = null): AztecBlockSpan {
         when (textFormat) {
-            TextFormat.FORMAT_ORDERED_LIST -> return AztecOrderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
-            TextFormat.FORMAT_UNORDERED_LIST -> return AztecUnorderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
-            TextFormat.FORMAT_QUOTE -> return AztecQuoteSpan(editor.quoteBackground, editor.quoteColor, editor.quoteMargin, editor.quoteWidth, editor.quotePadding, attrs)
+            TextFormat.FORMAT_ORDERED_LIST -> return AztecOrderedListSpan(listStyle, attrs)
+            TextFormat.FORMAT_UNORDERED_LIST -> return AztecUnorderedListSpan(listStyle, attrs)
+            TextFormat.FORMAT_QUOTE -> return AztecQuoteSpan(quoteStyle, attrs)
             else -> return ParagraphSpan(attrs)
         }
     }
@@ -204,9 +210,9 @@ class BlockFormatter(editor: AztecText) {
 
     fun makeBlockSpan(spanType: Class<AztecBlockSpan>, attrs: String? = null): AztecBlockSpan {
         when (spanType) {
-            AztecOrderedListSpan::class.java -> return AztecOrderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
-            AztecUnorderedListSpan::class.java -> return AztecUnorderedListSpan(editor.bulletColor, editor.bulletMargin, editor.bulletWidth, editor.bulletPadding, attrs)
-            AztecQuoteSpan::class.java -> return AztecQuoteSpan(editor.quoteBackground, editor.quoteColor, editor.quoteMargin, editor.quoteWidth, editor.quotePadding, attrs)
+            AztecOrderedListSpan::class.java -> return AztecOrderedListSpan(listStyle, attrs)
+            AztecUnorderedListSpan::class.java -> return AztecUnorderedListSpan(listStyle, attrs)
+            AztecQuoteSpan::class.java -> return AztecQuoteSpan(quoteStyle, attrs)
             else -> return ParagraphSpan(attrs)
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -23,6 +23,37 @@ class InlineFormatter(editor: AztecText) {
         this.editor = editor
     }
 
+    fun toggleBold(){
+        if (!containsInlineStyle(TextFormat.FORMAT_BOLD)) {
+            applyInlineStyle(TextFormat.FORMAT_BOLD)
+        } else {
+            removeInlineStyle(TextFormat.FORMAT_BOLD)
+        }
+    }
+
+    fun toggleItalic(){
+        if (!containsInlineStyle(TextFormat.FORMAT_ITALIC)) {
+            applyInlineStyle(TextFormat.FORMAT_ITALIC)
+        } else {
+            removeInlineStyle(TextFormat.FORMAT_ITALIC)
+        }
+    }
+
+    fun toggleUnderline(){
+        if (!containsInlineStyle(TextFormat.FORMAT_UNDERLINED)) {
+            applyInlineStyle(TextFormat.FORMAT_UNDERLINED)
+        } else {
+            removeInlineStyle(TextFormat.FORMAT_UNDERLINED)
+        }
+    }
+
+    fun toggleStrikethrough(){
+        if (!containsInlineStyle(TextFormat.FORMAT_STRIKETHROUGH)) {
+            applyInlineStyle(TextFormat.FORMAT_STRIKETHROUGH)
+        } else {
+            removeInlineStyle(TextFormat.FORMAT_STRIKETHROUGH)
+        }
+    }
 
     fun carryOverInlineSpans(start: Int, count: Int, after: Int) {
         carryOverSpans.clear()
@@ -107,7 +138,7 @@ class InlineFormatter(editor: AztecText) {
     }
 
 
-    public fun applyInlineStyle(textFormat: TextFormat, start: Int, end: Int) {
+     fun applyInlineStyle(textFormat: TextFormat, start: Int = editor.selectionStart, end: Int = editor.selectionEnd) {
         val spanToApply = makeInlineSpan(textFormat)
 
         if (start >= end) {
@@ -178,7 +209,7 @@ class InlineFormatter(editor: AztecText) {
         joinStyleSpans(start, end)
     }
 
-    fun removeInlineStyle(textFormat: TextFormat, start: Int, end: Int) {
+    fun removeInlineStyle(textFormat: TextFormat, start: Int = editor.selectionStart, end: Int = editor.selectionEnd) {
         //for convenience sake we are initializing the span of same type we are planing to remove
         val spanToRemove = makeInlineSpan(textFormat)
 
@@ -326,7 +357,7 @@ class InlineFormatter(editor: AztecText) {
     }
 
 
-    fun containsInlineStyle(textFormat: TextFormat, start: Int, end: Int): Boolean {
+    fun containsInlineStyle(textFormat: TextFormat, start: Int = editor.selectionStart, end: Int = editor.selectionEnd): Boolean {
         val spanToCheck = makeInlineSpan(textFormat)
 
         if (start > end) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -1,7 +1,6 @@
 package org.wordpress.aztec.formatting
 
 import android.graphics.Typeface
-import android.text.Editable
 import android.text.Spanned
 import android.text.style.StyleSpan
 import org.wordpress.aztec.AztecPart
@@ -76,7 +75,7 @@ class InlineFormatter(editor: AztecText):AztecFormatter(editor) {
     }
 
 
-    fun handleInlineStyling(text: Editable, textChangedEvent: TextChangedEvent) {
+    fun handleInlineStyling(textChangedEvent: TextChangedEvent) {
         //because we use SPAN_INCLUSIVE_INCLUSIVE for inline styles
         //we need to make sure unselected styles are not applied
         clearInlineStyles(textChangedEvent.inputStart, textChangedEvent.inputEnd, textChangedEvent.isNewLine())

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -11,16 +11,9 @@ import org.wordpress.aztec.spans.AztecHeadingSpan
 import java.util.*
 
 
-class LineBlockFormatter(editor: AztecText) {
+class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
 
-    val editor: AztecText
-
-    init {
-        this.editor = editor
-    }
-
-
-    fun applyHeading(textFormat: TextFormat){
+    fun applyHeading(textFormat: TextFormat) {
         headingClear()
 
         if (textFormat != TextFormat.FORMAT_PARAGRAPH) {
@@ -28,17 +21,17 @@ class LineBlockFormatter(editor: AztecText) {
         }
     }
 
-    fun applyMoreComment(){
+    fun applyMoreComment() {
         applyComment(AztecCommentSpan.Comment.MORE)
     }
 
-    fun applyPageComment(){
+    fun applyPageComment() {
         applyComment(AztecCommentSpan.Comment.PAGE)
     }
 
 
-     fun headingClear() {
-        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+    fun headingClear() {
+        val lines = TextUtils.split(editableText.toString(), "\n")
 
         for (i in lines.indices) {
             if (!containsHeading(i)) {
@@ -60,19 +53,19 @@ class LineBlockFormatter(editor: AztecText) {
             var headingStart = 0
             var headingEnd = 0
 
-            if ((lineStart <= editor.selectionStart && editor.selectionEnd <= lineEnd) ||
-                    (lineStart >= editor.selectionStart && editor.selectionEnd >= lineEnd) ||
-                    (lineStart <= editor.selectionStart && editor.selectionEnd >= lineEnd && editor.selectionStart <= lineEnd) ||
-                    (lineStart >= editor.selectionStart && editor.selectionEnd <= lineEnd && editor.selectionEnd >= lineStart)) {
+            if ((lineStart <= selectionStart && selectionEnd <= lineEnd) ||
+                    (lineStart >= selectionStart && selectionEnd >= lineEnd) ||
+                    (lineStart <= selectionStart && selectionEnd >= lineEnd && selectionStart <= lineEnd) ||
+                    (lineStart >= selectionStart && selectionEnd <= lineEnd && selectionEnd >= lineStart)) {
                 headingStart = lineStart
                 headingEnd = lineEnd
             }
 
             if (headingStart < headingEnd) {
-                val spans = editor.editableText.getSpans(headingStart, headingEnd, AztecHeadingSpan::class.java)
+                val spans = editableText.getSpans(headingStart, headingEnd, AztecHeadingSpan::class.java)
 
                 for (span in spans) {
-                    editor.editableText.removeSpan(span)
+                    editableText.removeSpan(span)
                 }
             }
         }
@@ -80,8 +73,8 @@ class LineBlockFormatter(editor: AztecText) {
         editor.refreshText()
     }
 
-     fun headingFormat(textFormat: TextFormat) {
-        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+    fun headingFormat(textFormat: TextFormat) {
+        val lines = TextUtils.split(editableText.toString(), "\n")
 
         for (i in lines.indices) {
             var lineStart = 0
@@ -99,10 +92,10 @@ class LineBlockFormatter(editor: AztecText) {
             var headingStart = 0
             var headingEnd = 0
 
-            if ((lineStart <= editor.selectionStart && editor.selectionEnd <= lineEnd) ||
-                    (lineStart >= editor.selectionStart && editor.selectionEnd >= lineEnd) ||
-                    (lineStart <= editor.selectionStart && editor.selectionEnd >= lineEnd && editor.selectionStart <= lineEnd) ||
-                    (lineStart >= editor.selectionStart && editor.selectionEnd <= lineEnd && editor.selectionEnd >= lineStart)) {
+            if ((lineStart <= selectionStart && selectionEnd <= lineEnd) ||
+                    (lineStart >= selectionStart && selectionEnd >= lineEnd) ||
+                    (lineStart <= selectionStart && selectionEnd >= lineEnd && selectionStart <= lineEnd) ||
+                    (lineStart >= selectionStart && selectionEnd <= lineEnd && selectionEnd >= lineStart)) {
                 headingStart = lineStart
                 headingEnd = lineEnd
             }
@@ -110,17 +103,17 @@ class LineBlockFormatter(editor: AztecText) {
             if (headingStart < headingEnd) {
                 when (textFormat) {
                     TextFormat.FORMAT_HEADING_1 ->
-                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H1), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H1), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     TextFormat.FORMAT_HEADING_2 ->
-                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H2), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H2), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     TextFormat.FORMAT_HEADING_3 ->
-                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H3), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H3), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     TextFormat.FORMAT_HEADING_4 ->
-                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H4), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H4), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     TextFormat.FORMAT_HEADING_5 ->
-                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H5), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H5), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     TextFormat.FORMAT_HEADING_6 ->
-                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H6), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                        editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H6), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                     else -> {
                     }
                 }
@@ -130,8 +123,8 @@ class LineBlockFormatter(editor: AztecText) {
         editor.refreshText()
     }
 
-     fun containsHeading(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
-        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+    fun containsHeading(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
+        val lines = TextUtils.split(editableText.toString(), "\n")
         val list = ArrayList<Int>()
 
         for (i in lines.indices) {
@@ -163,8 +156,8 @@ class LineBlockFormatter(editor: AztecText) {
         return true
     }
 
-     fun containsHeading(index: Int): Boolean {
-        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+    fun containsHeading(index: Int): Boolean {
+        val lines = TextUtils.split(editableText.toString(), "\n")
 
         if (index < 0 || index >= lines.size) {
             return false
@@ -182,12 +175,12 @@ class LineBlockFormatter(editor: AztecText) {
             return false
         }
 
-        val spans = editor.editableText.getSpans(start, end, AztecHeadingSpan::class.java)
+        val spans = editableText.getSpans(start, end, AztecHeadingSpan::class.java)
         return spans.size > 0
     }
 
     private fun containHeadingType(textFormat: TextFormat, index: Int): Boolean {
-        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+        val lines = TextUtils.split(editableText.toString(), "\n")
 
         if (index < 0 || index >= lines.size) {
             return false
@@ -205,7 +198,7 @@ class LineBlockFormatter(editor: AztecText) {
             return false
         }
 
-        val spans = editor.editableText.getSpans(start, end, AztecHeadingSpan::class.java)
+        val spans = editableText.getSpans(start, end, AztecHeadingSpan::class.java)
 
         for (span in spans) {
             when (textFormat) {
@@ -231,18 +224,18 @@ class LineBlockFormatter(editor: AztecText) {
     private fun applyComment(comment: AztecCommentSpan.Comment) {
         //check if we add a comment into a block element, at the end of the line, but not at the end of last line
         var applyingOnTheEndOfBlockLine = false
-        editor.editableText.getSpans(editor.selectionStart, editor.selectionEnd, AztecBlockSpan::class.java).forEach {
-            if (editor.editableText.getSpanEnd(it) > editor.selectionEnd && editor.editableText[editor.selectionEnd] == '\n') {
+        editableText.getSpans(selectionStart, selectionEnd, AztecBlockSpan::class.java).forEach {
+            if (editableText.getSpanEnd(it) > selectionEnd && editableText[selectionEnd] == '\n') {
                 applyingOnTheEndOfBlockLine = true
                 return@forEach
             }
         }
 
-        val commentStartIndex = editor.selectionStart + 1
-        val commentEndIndex = editor.selectionStart + comment.html.length + 1
+        val commentStartIndex = selectionStart + 1
+        val commentEndIndex = selectionStart + comment.html.length + 1
 
         editor.disableTextChangedListener()
-        editor.editableText.replace(editor.selectionStart, editor.selectionEnd, "\n" + comment.html + if (applyingOnTheEndOfBlockLine) "" else "\n")
+        editableText.replace(selectionStart, selectionEnd, "\n" + comment.html + if (applyingOnTheEndOfBlockLine) "" else "\n")
 
         editor.removeBlockStylesFromRange(commentStartIndex, commentEndIndex + 1, true)
         editor.removeHeadingStylesFromRange(commentStartIndex, commentEndIndex + 1)
@@ -256,7 +249,7 @@ class LineBlockFormatter(editor: AztecText) {
                 }
         )
 
-        editor.editableText.setSpan(
+        editableText.setSpan(
                 span,
                 commentStartIndex,
                 commentEndIndex,

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -228,13 +228,7 @@ class LineBlockFormatter(editor: AztecText) {
         return false
     }
 
-    private fun getCommentHtml(textFormat: TextFormat): String{
-        if(textFormat == TextFormat.FORMAT_MORE) return AztecCommentSpan.Comment.MORE.html
-        if(textFormat == TextFormat.FORMAT_PAGE) return AztecCommentSpan.Comment.PAGE.html
-        return ""
-    }
-
-    fun applyComment(comment: AztecCommentSpan.Comment) {
+    private fun applyComment(comment: AztecCommentSpan.Comment) {
         //check if we add a comment into a block element, at the end of the line, but not at the end of last line
         var applyingOnTheEndOfBlockLine = false
         editor.editableText.getSpans(editor.selectionStart, editor.selectionEnd, AztecBlockSpan::class.java).forEach {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -20,6 +20,23 @@ class LineBlockFormatter(editor: AztecText) {
     }
 
 
+    fun applyHeading(textFormat: TextFormat){
+        headingClear()
+
+        if (textFormat != TextFormat.FORMAT_PARAGRAPH) {
+            headingFormat(textFormat)
+        }
+    }
+
+    fun applyMoreComment(){
+        applyComment(AztecCommentSpan.Comment.MORE)
+    }
+
+    fun applyPageComment(){
+        applyComment(AztecCommentSpan.Comment.PAGE)
+    }
+
+
      fun headingClear() {
         val lines = TextUtils.split(editor.editableText.toString(), "\n")
 
@@ -193,17 +210,17 @@ class LineBlockFormatter(editor: AztecText) {
         for (span in spans) {
             when (textFormat) {
                 TextFormat.FORMAT_HEADING_1 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H1)
+                    return span.heading == AztecHeadingSpan.Heading.H1
                 TextFormat.FORMAT_HEADING_2 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H2)
+                    return span.heading == AztecHeadingSpan.Heading.H2
                 TextFormat.FORMAT_HEADING_3 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H3)
+                    return span.heading == AztecHeadingSpan.Heading.H3
                 TextFormat.FORMAT_HEADING_4 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H4)
+                    return span.heading == AztecHeadingSpan.Heading.H4
                 TextFormat.FORMAT_HEADING_5 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H5)
+                    return span.heading == AztecHeadingSpan.Heading.H5
                 TextFormat.FORMAT_HEADING_6 ->
-                    return span.heading.equals(AztecHeadingSpan.Heading.H6)
+                    return span.heading == AztecHeadingSpan.Heading.H6
                 else -> return false
             }
         }
@@ -211,7 +228,11 @@ class LineBlockFormatter(editor: AztecText) {
         return false
     }
 
-
+    private fun getCommentHtml(textFormat: TextFormat): String{
+        if(textFormat == TextFormat.FORMAT_MORE) return AztecCommentSpan.Comment.MORE.html
+        if(textFormat == TextFormat.FORMAT_PAGE) return AztecCommentSpan.Comment.PAGE.html
+        return ""
+    }
 
     fun applyComment(comment: AztecCommentSpan.Comment) {
         //check if we add a comment into a block element, at the end of the line, but not at the end of last line

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -1,5 +1,6 @@
 package org.wordpress.aztec.formatting
 
+import android.support.v4.content.ContextCompat
 import android.text.Spanned
 import android.text.TextUtils
 import org.wordpress.aztec.AztecText
@@ -244,8 +245,8 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
         val span = AztecCommentSpan(
                 editor.context,
                 when (comment) {
-                    AztecCommentSpan.Comment.MORE -> editor.resources.getDrawable(R.drawable.img_more)
-                    AztecCommentSpan.Comment.PAGE -> editor.resources.getDrawable(R.drawable.img_page)
+                    AztecCommentSpan.Comment.MORE -> ContextCompat.getDrawable(editor.context, R.drawable.img_more)
+                    AztecCommentSpan.Comment.PAGE -> ContextCompat.getDrawable(editor.context, R.drawable.img_page)
                 }
         )
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -1,0 +1,255 @@
+package org.wordpress.aztec.formatting
+
+import android.text.Spanned
+import android.text.TextUtils
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.R
+import org.wordpress.aztec.TextFormat
+import org.wordpress.aztec.spans.AztecBlockSpan
+import org.wordpress.aztec.spans.AztecCommentSpan
+import org.wordpress.aztec.spans.AztecHeadingSpan
+import java.util.*
+
+
+class LineBlockFormatter(editor: AztecText) {
+
+    val editor: AztecText
+
+    init {
+        this.editor = editor
+    }
+
+
+     fun headingClear() {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+
+        for (i in lines.indices) {
+            if (!containsHeading(i)) {
+                continue
+            }
+
+            var lineStart = 0
+
+            for (j in 0..i - 1) {
+                lineStart += lines[j].length + 1
+            }
+
+            val lineEnd = lineStart + lines[i].length
+
+            if (lineStart >= lineEnd) {
+                continue
+            }
+
+            var headingStart = 0
+            var headingEnd = 0
+
+            if ((lineStart <= editor.selectionStart && editor.selectionEnd <= lineEnd) ||
+                    (lineStart >= editor.selectionStart && editor.selectionEnd >= lineEnd) ||
+                    (lineStart <= editor.selectionStart && editor.selectionEnd >= lineEnd && editor.selectionStart <= lineEnd) ||
+                    (lineStart >= editor.selectionStart && editor.selectionEnd <= lineEnd && editor.selectionEnd >= lineStart)) {
+                headingStart = lineStart
+                headingEnd = lineEnd
+            }
+
+            if (headingStart < headingEnd) {
+                val spans = editor.editableText.getSpans(headingStart, headingEnd, AztecHeadingSpan::class.java)
+
+                for (span in spans) {
+                    editor.editableText.removeSpan(span)
+                }
+            }
+        }
+
+        editor.refreshText()
+    }
+
+     fun headingFormat(textFormat: TextFormat) {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+
+        for (i in lines.indices) {
+            var lineStart = 0
+
+            for (j in 0..i - 1) {
+                lineStart += lines[j].length + 1
+            }
+
+            val lineEnd = lineStart + lines[i].length
+
+            if (lineStart >= lineEnd) {
+                continue
+            }
+
+            var headingStart = 0
+            var headingEnd = 0
+
+            if ((lineStart <= editor.selectionStart && editor.selectionEnd <= lineEnd) ||
+                    (lineStart >= editor.selectionStart && editor.selectionEnd >= lineEnd) ||
+                    (lineStart <= editor.selectionStart && editor.selectionEnd >= lineEnd && editor.selectionStart <= lineEnd) ||
+                    (lineStart >= editor.selectionStart && editor.selectionEnd <= lineEnd && editor.selectionEnd >= lineStart)) {
+                headingStart = lineStart
+                headingEnd = lineEnd
+            }
+
+            if (headingStart < headingEnd) {
+                when (textFormat) {
+                    TextFormat.FORMAT_HEADING_1 ->
+                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H1), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    TextFormat.FORMAT_HEADING_2 ->
+                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H2), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    TextFormat.FORMAT_HEADING_3 ->
+                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H3), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    TextFormat.FORMAT_HEADING_4 ->
+                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H4), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    TextFormat.FORMAT_HEADING_5 ->
+                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H5), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    TextFormat.FORMAT_HEADING_6 ->
+                        editor.editableText.setSpan(AztecHeadingSpan(AztecHeadingSpan.Heading.H6), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                    else -> {
+                    }
+                }
+            }
+        }
+
+        editor.refreshText()
+    }
+
+     fun containsHeading(textFormat: TextFormat, selStart: Int, selEnd: Int): Boolean {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+        val list = ArrayList<Int>()
+
+        for (i in lines.indices) {
+            var lineStart = 0
+            for (j in 0..i - 1) {
+                lineStart += lines[j].length + 1
+            }
+
+            val lineEnd = lineStart + lines[i].length
+            if (lineStart >= lineEnd) {
+                continue
+            }
+
+            if (lineStart <= selStart && selEnd <= lineEnd) {
+                list.add(i)
+            } else if (selStart <= lineStart && lineEnd <= selEnd) {
+                list.add(i)
+            }
+        }
+
+        if (list.isEmpty()) return false
+
+        for (i in list) {
+            if (!containHeadingType(textFormat, i)) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+     fun containsHeading(index: Int): Boolean {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+
+        if (index < 0 || index >= lines.size) {
+            return false
+        }
+
+        var start = 0
+
+        for (i in 0..index - 1) {
+            start += lines[i].length + 1
+        }
+
+        val end = start + lines[index].length
+
+        if (start >= end) {
+            return false
+        }
+
+        val spans = editor.editableText.getSpans(start, end, AztecHeadingSpan::class.java)
+        return spans.size > 0
+    }
+
+    private fun containHeadingType(textFormat: TextFormat, index: Int): Boolean {
+        val lines = TextUtils.split(editor.editableText.toString(), "\n")
+
+        if (index < 0 || index >= lines.size) {
+            return false
+        }
+
+        var start = 0
+
+        for (i in 0..index - 1) {
+            start += lines[i].length + 1
+        }
+
+        val end = start + lines[index].length
+
+        if (start >= end) {
+            return false
+        }
+
+        val spans = editor.editableText.getSpans(start, end, AztecHeadingSpan::class.java)
+
+        for (span in spans) {
+            when (textFormat) {
+                TextFormat.FORMAT_HEADING_1 ->
+                    return span.heading.equals(AztecHeadingSpan.Heading.H1)
+                TextFormat.FORMAT_HEADING_2 ->
+                    return span.heading.equals(AztecHeadingSpan.Heading.H2)
+                TextFormat.FORMAT_HEADING_3 ->
+                    return span.heading.equals(AztecHeadingSpan.Heading.H3)
+                TextFormat.FORMAT_HEADING_4 ->
+                    return span.heading.equals(AztecHeadingSpan.Heading.H4)
+                TextFormat.FORMAT_HEADING_5 ->
+                    return span.heading.equals(AztecHeadingSpan.Heading.H5)
+                TextFormat.FORMAT_HEADING_6 ->
+                    return span.heading.equals(AztecHeadingSpan.Heading.H6)
+                else -> return false
+            }
+        }
+
+        return false
+    }
+
+
+
+    fun applyComment(comment: AztecCommentSpan.Comment) {
+        //check if we add a comment into a block element, at the end of the line, but not at the end of last line
+        var applyingOnTheEndOfBlockLine = false
+        editor.editableText.getSpans(editor.selectionStart, editor.selectionEnd, AztecBlockSpan::class.java).forEach {
+            if (editor.editableText.getSpanEnd(it) > editor.selectionEnd && editor.editableText[editor.selectionEnd] == '\n') {
+                applyingOnTheEndOfBlockLine = true
+                return@forEach
+            }
+        }
+
+        val commentStartIndex = editor.selectionStart + 1
+        val commentEndIndex = editor.selectionStart + comment.html.length + 1
+
+        editor.disableTextChangedListener()
+        editor.editableText.replace(editor.selectionStart, editor.selectionEnd, "\n" + comment.html + if (applyingOnTheEndOfBlockLine) "" else "\n")
+
+        editor.removeBlockStylesFromRange(commentStartIndex, commentEndIndex + 1, true)
+        editor.removeHeadingStylesFromRange(commentStartIndex, commentEndIndex + 1)
+        editor.removeInlineStylesFromRange(commentStartIndex, commentEndIndex + 1)
+
+        val span = AztecCommentSpan(
+                editor.context,
+                when (comment) {
+                    AztecCommentSpan.Comment.MORE -> editor.resources.getDrawable(R.drawable.img_more)
+                    AztecCommentSpan.Comment.PAGE -> editor.resources.getDrawable(R.drawable.img_page)
+                }
+        )
+
+        editor.editableText.setSpan(
+                span,
+                commentStartIndex,
+                commentEndIndex,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+
+        editor.setSelection(commentEndIndex + 1)
+    }
+
+
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
@@ -1,0 +1,186 @@
+package org.wordpress.aztec.formatting
+
+import android.content.Context
+import android.text.Spanned
+import android.text.TextUtils
+import android.util.Patterns
+import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.spans.AztecURLSpan
+
+
+class LinkFormatter(editor: AztecText) {
+
+    val editor: AztecText
+
+    init {
+        this.editor = editor
+    }
+
+
+    fun isUrlSelected(): Boolean {
+        val urlSpans = editor.editableText.getSpans(editor.selectionStart, editor.selectionEnd, AztecURLSpan::class.java)
+        return !urlSpans.isEmpty()
+    }
+
+    fun getSelectedUrlWithAnchor(): Pair<String, String> {
+        val url: String
+        var anchor: String
+
+        if (!isUrlSelected()) {
+            val clipboardUrl = getUrlFromClipboard(editor.context)
+
+            url = if (TextUtils.isEmpty(clipboardUrl)) "" else clipboardUrl
+            anchor = if (editor.selectionStart == editor.selectionEnd) "" else editor.getSelectedText()
+
+        } else {
+            val urlSpans = editor.editableText.getSpans(editor.selectionStart, editor.selectionEnd, AztecURLSpan::class.java)
+            val urlSpan = urlSpans[0]
+
+            val spanStart = editor.editableText.getSpanStart(urlSpan)
+            val spanEnd = editor.editableText.getSpanEnd(urlSpan)
+
+            if (editor.selectionStart < spanStart || editor.selectionEnd > spanEnd) {
+                //looks like some text that is not part of the url was included in selection
+                anchor = editor.getSelectedText()
+                url = ""
+            } else {
+                anchor = editor.editableText.substring(spanStart, spanEnd)
+                url = urlSpan.url
+            }
+
+            if (anchor == url) {
+                anchor = ""
+            }
+        }
+
+        return Pair(url, anchor)
+
+    }
+
+    /**
+     * Checks the Clipboard for text that matches the [Patterns.WEB_URL] pattern.
+     * @return the URL text in the clipboard, if it exists; otherwise null
+     */
+    fun getUrlFromClipboard(context: Context?): String {
+        if (context == null) return ""
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+
+        val data = clipboard.primaryClip
+        if (data == null || data.itemCount <= 0) return ""
+        val clipText = data.getItemAt(0).text.toString()
+        return if (Patterns.WEB_URL.matcher(clipText).matches()) clipText else ""
+    }
+
+    fun getUrlSpanBounds(): Pair<Int, Int> {
+        val urlSpans = editor.editableText.getSpans(editor.selectionStart, editor.selectionEnd, AztecURLSpan::class.java)
+
+        val spanStart = editor.editableText.getSpanStart(urlSpans[0])
+        val spanEnd = editor.editableText.getSpanEnd(urlSpans[0])
+
+        if (editor.selectionStart < spanStart || editor.selectionEnd > spanEnd) {
+            //looks like some text that is not part of the url was included in selection
+            return Pair(editor.selectionStart, editor.selectionEnd)
+        }
+        return Pair(spanStart, spanEnd)
+    }
+
+
+    fun addLink(link: String, anchor: String, start: Int, end: Int) {
+        val cleanLink = link.trim()
+        val newEnd: Int
+
+        val actualAnchor = if (TextUtils.isEmpty(anchor)) cleanLink else anchor
+
+        if (start == end) {
+            //insert anchor
+            editor.editableText.insert(start, actualAnchor)
+            newEnd = start + actualAnchor.length
+        } else {
+            //apply span to text
+            if (editor.getSelectedText() != anchor) {
+                editor.editableText.replace(start, end, actualAnchor)
+            }
+            newEnd = start + actualAnchor.length
+        }
+
+        linkValid(link, start, newEnd)
+    }
+
+    fun editLink(link: String, anchor: String?, start: Int = editor.selectionStart, end: Int = editor.selectionEnd) {
+        val cleanLink = link.trim()
+        val newEnd: Int
+
+        if (TextUtils.isEmpty(anchor)) {
+            editor.editableText.replace(start, end, cleanLink)
+            newEnd = start + cleanLink.length
+        } else {
+            //if the anchor was not changed do nothing to preserve original style of text
+            if (editor.getSelectedText() != anchor) {
+                editor.editableText.replace(start, end, anchor)
+            }
+            newEnd = start + anchor!!.length
+        }
+
+        var attributes = getAttributes(end, start)
+        attributes = attributes?.replace("href=[\"'].*[\"']".toRegex(), "href=\"$cleanLink\"")
+
+        linkValid(cleanLink, start, newEnd, attributes)
+    }
+
+    private fun getAttributes(end: Int, start: Int): String? {
+        val urlSpans = editor.editableText.getSpans(start, end, AztecURLSpan::class.java)
+        var attributes: String? = null
+        if (urlSpans != null && urlSpans.size > 0) {
+            attributes = urlSpans[0].attributes
+        }
+        return attributes
+    }
+
+
+    private fun linkValid(link: String, start: Int, end: Int, attributes: String? = null) {
+        if (start >= end) {
+            return
+        }
+
+        linkInvalid(start, end)
+        editor.editableText.setSpan(AztecURLSpan(link, editor.linkColor, editor.linkUnderline, attributes), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        editor.onSelectionChanged(end, end)
+    }
+
+    fun linkInvalid(start: Int, end: Int) {
+        if (start >= end) {
+            return
+        }
+
+        val spans = editor.editableText.getSpans(start, end, AztecURLSpan::class.java)
+        for (span in spans) {
+            editor.editableText.removeSpan(span)
+        }
+    }
+
+    fun containLink(start: Int, end: Int): Boolean {
+        if (start > end) {
+            return false
+        }
+
+        if (start == end) {
+            if (start - 1 < 0 || start + 1 > editor.editableText.length) {
+                return false
+            } else {
+                val before =editor.editableText.getSpans(start - 1, start, AztecURLSpan::class.java)
+                val after = editor.editableText.getSpans(start, start + 1, AztecURLSpan::class.java)
+                return before.size > 0 && after.size > 0
+            }
+        } else {
+            val builder = StringBuilder()
+
+            for (i in start..end - 1) {
+                if (editor.editableText.getSpans(i, i + 1, AztecURLSpan::class.java).size > 0) {
+                    builder.append(editor.editableText.subSequence(i, i + 1).toString())
+                }
+            }
+
+            return editor.editableText.subSequence(start, end).toString() == builder.toString()
+        }
+    }
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LinkFormatter.kt
@@ -8,12 +8,16 @@ import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.spans.AztecURLSpan
 
 
-class LinkFormatter(editor: AztecText) {
+class LinkFormatter(editor: AztecText, linkStyle: LinkStyle) {
+
+    data class LinkStyle(val linkColor: Int, val linkUnderline: Boolean)
 
     val editor: AztecText
+    val linkStyle: LinkStyle
 
     init {
         this.editor = editor
+        this.linkStyle = linkStyle
     }
 
 
@@ -136,6 +140,9 @@ class LinkFormatter(editor: AztecText) {
         return attributes
     }
 
+    fun makeUrlSpan(url: String, attrs: String? = null): AztecURLSpan {
+        return AztecURLSpan(url, linkStyle, attrs)
+    }
 
     private fun linkValid(link: String, start: Int, end: Int, attributes: String? = null) {
         if (start >= end) {
@@ -143,7 +150,7 @@ class LinkFormatter(editor: AztecText) {
         }
 
         linkInvalid(start, end)
-        editor.editableText.setSpan(AztecURLSpan(link, editor.linkColor, editor.linkUnderline, attributes), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        editor.editableText.setSpan(AztecURLSpan(link, linkStyle, attributes), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         editor.onSelectionChanged(end, end)
     }
 
@@ -167,7 +174,7 @@ class LinkFormatter(editor: AztecText) {
             if (start - 1 < 0 || start + 1 > editor.editableText.length) {
                 return false
             } else {
-                val before =editor.editableText.getSpans(start - 1, start, AztecURLSpan::class.java)
+                val before = editor.editableText.getSpans(start - 1, start, AztecURLSpan::class.java)
                 val after = editor.editableText.getSpans(start, start + 1, AztecURLSpan::class.java)
                 return before.size > 0 && after.size > 0
             }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -24,6 +24,7 @@ import android.text.Layout
 import android.text.Spanned
 import android.text.TextUtils
 import android.text.style.LeadingMarginSpan
+import org.wordpress.aztec.formatting.BlockFormatter
 
 class AztecOrderedListSpan : LeadingMarginSpan.Standard, AztecListSpan {
 
@@ -45,11 +46,11 @@ class AztecOrderedListSpan : LeadingMarginSpan.Standard, AztecListSpan {
         this.attributes = attributes
     }
 
-    constructor(textColor: Int, textMargin: Int, bulletWidth: Int, textPadding: Int, attributes: String? = null) : super(textMargin) {
-        this.textColor = textColor
-        this.textMargin = textMargin
-        this.bulletWidth = bulletWidth
-        this.textPadding = textPadding
+    constructor(listStyle: BlockFormatter.ListStyle, attributes: String? = null) : super(listStyle.indicatorMargin) {
+        this.textColor = listStyle.indicatorColor
+        this.textMargin = listStyle.indicatorMargin
+        this.bulletWidth = listStyle.indicatorWidth
+        this.textPadding = listStyle.indicatorPadding
         this.attributes = attributes
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -25,6 +25,7 @@ import android.text.Layout
 import android.text.TextUtils
 import android.text.style.LineBackgroundSpan
 import android.text.style.QuoteSpan
+import org.wordpress.aztec.formatting.BlockFormatter
 
 
 class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan {
@@ -46,12 +47,12 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan {
         this.attributes = attributes
     }
 
-    constructor(quoteBackground: Int, quoteColor: Int, quoteMargin: Int, quoteWidth: Int, quotePadding: Int, attributes: String? = null) : this(attributes) {
-        this.quoteBackground = quoteBackground
-        this.quoteColor = quoteColor
-        this.quoteMargin = quoteMargin
-        this.quoteWidth = quoteWidth
-        this.quotePadding = quotePadding
+    constructor(quoteStyle: BlockFormatter.QuoteStyle, attributes: String? = null) : this(attributes) {
+        this.quoteBackground = quoteStyle.quoteBackground
+        this.quoteColor = quoteStyle.quoteColor
+        this.quoteMargin = quoteStyle.quoteMargin
+        this.quoteWidth = quoteStyle.quoteWidth
+        this.quotePadding = quoteStyle.quotePadding
     }
 
     constructor(src: Parcel) : super(src) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecURLSpan.kt
@@ -21,6 +21,7 @@ import android.os.Parcel
 import android.text.TextPaint
 import android.text.TextUtils
 import android.text.style.URLSpan
+import org.wordpress.aztec.formatting.LinkFormatter
 
 class AztecURLSpan : URLSpan, AztecContentSpan, AztecInlineSpan {
 
@@ -39,9 +40,9 @@ class AztecURLSpan : URLSpan, AztecContentSpan, AztecInlineSpan {
         }
     }
 
-    constructor(url: String, linkColor: Int, linkUnderline: Boolean, attributes: String? = null) : this(url, attributes) {
-        this.linkColor = linkColor
-        this.linkUnderline = linkUnderline
+    constructor(url: String, linkStyle: LinkFormatter.LinkStyle, attributes: String? = null) : this(url, attributes) {
+        this.linkColor = linkStyle.linkColor
+        this.linkUnderline = linkStyle.linkUnderline
     }
 
     constructor(src: Parcel) : super(src) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -24,6 +24,7 @@ import android.os.Parcel
 import android.text.Layout
 import android.text.TextUtils
 import android.text.style.BulletSpan
+import org.wordpress.aztec.formatting.BlockFormatter
 
 class AztecUnorderedListSpan : BulletSpan, AztecListSpan {
 
@@ -45,11 +46,11 @@ class AztecUnorderedListSpan : BulletSpan, AztecListSpan {
         this.attributes = attributes
     }
 
-    constructor(bulletColor: Int, bulletMargin: Int, bulletWidth: Int, bulletPadding: Int, attributes: String? = null) {
-        this.bulletColor = bulletColor
-        this.bulletMargin = bulletMargin
-        this.bulletWidth = bulletWidth
-        this.bulletPadding = bulletPadding
+    constructor(listStyle: BlockFormatter.ListStyle, attributes: String? = null) {
+        this.bulletColor = listStyle.indicatorColor
+        this.bulletMargin = listStyle.indicatorMargin
+        this.bulletWidth = listStyle.indicatorWidth
+        this.bulletPadding = listStyle.indicatorPadding
         this.attributes = attributes
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
@@ -10,6 +10,13 @@ import java.util.*
 enum class ToolbarAction constructor(val buttonId: Int, val actionType: ToolbarActionType, val textFormat: TextFormat?) {
     ADD_MEDIA(R.id.format_bar_button_media, ToolbarActionType.OTHER, null),
     HEADING(R.id.format_bar_button_heading, ToolbarActionType.OTHER, null),
+//    PARAGRAPH(R.id.paragraph, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_PARAGRAPH),
+//    HEADING_1(R.id.heading_1, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_1),
+//    HEADING_2(R.id.heading_2, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_2),
+//    HEADING_3(R.id.heading_3, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_3),
+//    HEADING_4(R.id.heading_4, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_4),
+//    HEADING_5(R.id.heading_5, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_5),
+//    HEADING_6(R.id.heading_6, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_6),
     BOLD(R.id.format_bar_button_bold, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_BOLD),
     ITALIC(R.id.format_bar_button_italic, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_ITALIC),
     STRIKETHROUGH(R.id.format_bar_button_strikethrough, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_STRIKETHROUGH),
@@ -17,8 +24,8 @@ enum class ToolbarAction constructor(val buttonId: Int, val actionType: ToolbarA
     ORDERED_LIST(R.id.format_bar_button_ol, ToolbarActionType.BLOCK_STYLE, TextFormat.FORMAT_ORDERED_LIST),
     QUOTE(R.id.format_bar_button_quote, ToolbarActionType.BLOCK_STYLE, TextFormat.FORMAT_QUOTE),
     LINK(R.id.format_bar_button_link, ToolbarActionType.OTHER, TextFormat.FORMAT_LINK),
-    MORE(R.id.format_bar_button_more, ToolbarActionType.OTHER, TextFormat.FORMAT_MORE),
-    PAGE(R.id.format_bar_button_page, ToolbarActionType.OTHER, TextFormat.FORMAT_PAGE),
+    MORE(R.id.format_bar_button_more, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_MORE),
+    PAGE(R.id.format_bar_button_page, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_PAGE),
     HTML(R.id.format_bar_button_html, ToolbarActionType.OTHER, null);
 
     companion object {
@@ -41,6 +48,6 @@ enum class ToolbarAction constructor(val buttonId: Int, val actionType: ToolbarA
     }
 
     fun isStylingAction(): Boolean {
-        return actionType == ToolbarActionType.INLINE_STYLE || actionType == ToolbarActionType.BLOCK_STYLE
+        return actionType != ToolbarActionType.OTHER
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarAction.kt
@@ -10,13 +10,6 @@ import java.util.*
 enum class ToolbarAction constructor(val buttonId: Int, val actionType: ToolbarActionType, val textFormat: TextFormat?) {
     ADD_MEDIA(R.id.format_bar_button_media, ToolbarActionType.OTHER, null),
     HEADING(R.id.format_bar_button_heading, ToolbarActionType.OTHER, null),
-//    PARAGRAPH(R.id.paragraph, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_PARAGRAPH),
-//    HEADING_1(R.id.heading_1, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_1),
-//    HEADING_2(R.id.heading_2, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_2),
-//    HEADING_3(R.id.heading_3, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_3),
-//    HEADING_4(R.id.heading_4, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_4),
-//    HEADING_5(R.id.heading_5, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_5),
-//    HEADING_6(R.id.heading_6, ToolbarActionType.LINE_BLOCK, TextFormat.FORMAT_HEADING_6),
     BOLD(R.id.format_bar_button_bold, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_BOLD),
     ITALIC(R.id.format_bar_button_italic, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_ITALIC),
     STRIKETHROUGH(R.id.format_bar_button_strikethrough, ToolbarActionType.INLINE_STYLE, TextFormat.FORMAT_STRIKETHROUGH),

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarActionType.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/ToolbarActionType.kt
@@ -4,5 +4,5 @@ package org.wordpress.aztec.toolbar
  * Describes types of actions that can be performed by toolbar
  */
 enum class ToolbarActionType {
-    INLINE_STYLE, BLOCK_STYLE, OTHER
+    INLINE_STYLE, BLOCK_STYLE, LINE_BLOCK, OTHER
 }

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -21,4 +21,24 @@
         <item name="android:background">@color/sourceview_separator</item>
     </style>
 
+    <style name="AztecTextStyle">
+        <item name="android:textCursorDrawable">?attr/textColor</item>
+        <item name="backgroundColor">@android:color/transparent</item>
+        <item name="bulletColor">@color/blue_medium</item>
+        <item name="bulletMargin">@dimen/bullet_margin</item>
+        <item name="bulletPadding">@dimen/bullet_padding</item>
+        <item name="bulletWidth">@dimen/bullet_width</item>
+        <item name="lineSpacingExtra">@dimen/spacing_extra</item>
+        <item name="lineSpacingMultiplier">@dimen/spacing_multiplier</item>
+        <item name="linkColor">@color/blue_wordpress</item>
+        <item name="linkUnderline">false</item>
+        <item name="quoteBackground">@color/blue_wordpress</item>
+        <item name="quoteColor">@color/blue_medium</item>
+        <item name="quoteMargin">@dimen/quote_margin</item>
+        <item name="quotePadding">@dimen/quote_padding</item>
+        <item name="quoteWidth">@dimen/quote_width</item>
+        <item name="textColor">@android:color/white</item>
+        <item name="textColorHint">@android:color/darker_gray</item>
+    </style>
+
 </resources>

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecCommentTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecCommentTest.kt
@@ -65,7 +65,7 @@ class AztecCommentTest() : AndroidTestCase() {
         val html = HTML_LIST_ORDERED + HTML_LIST_UNORDERED + HTML_QUOTE
         editText.fromHtml(html)
         editText.setSelection(2, 20) // select between second character of ordered list and second character of quote (includes newline characters)
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED_SELECTED_1$HTML_COMMENT_MORE$HTML_QUOTE_SPLIT_2", editText.toHtml())
     }
@@ -83,7 +83,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(editText.length()) // select after list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED$HTML_COMMENT_MORE<br>", editText.toHtml())
     }
@@ -101,7 +101,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(editText.length()) // select after quote
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_QUOTE$HTML_COMMENT_MORE<br>", editText.toHtml())
     }
@@ -119,7 +119,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(editText.length()) // select after list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_LIST_UNORDERED$HTML_COMMENT_MORE<br>", editText.toHtml())
     }
@@ -137,7 +137,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(0) // select before list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("<br>$HTML_COMMENT_MORE$HTML_LIST_ORDERED", editText.toHtml())
     }
@@ -155,7 +155,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(0) // select before quote
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("<br>$HTML_COMMENT_MORE$HTML_QUOTE", editText.toHtml())
     }
@@ -173,7 +173,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(0) // select before list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("<br>$HTML_COMMENT_MORE$HTML_LIST_UNORDERED", editText.toHtml())
     }
@@ -192,7 +192,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(2) // select after second character in list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED_SPLIT_1$HTML_COMMENT_MORE$HTML_LIST_ORDERED_SPLIT_2", editText.toHtml())
     }
@@ -211,7 +211,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(2) // select after second character in quote
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_QUOTE_SPLIT_1$HTML_COMMENT_MORE$HTML_QUOTE_SPLIT_2", editText.toHtml())
     }
@@ -230,7 +230,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(2) // select after second character in list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_LIST_UNORDERED_SPLIT_1$HTML_COMMENT_MORE$HTML_LIST_UNORDERED_SPLIT_2", editText.toHtml())
     }
@@ -249,7 +249,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(2, 4) // select between second and fourth character in list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED_SELECTED_1$HTML_COMMENT_MORE$HTML_LIST_ORDERED_SELECTED_2", editText.toHtml())
     }
@@ -268,7 +268,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(2, 4) // select between second and fourth character in quote
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_QUOTE_SELECTED_1$HTML_COMMENT_MORE$HTML_QUOTE_SELECTED_2", editText.toHtml())
     }
@@ -287,7 +287,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(2, 4) // select between second and fourth character in list
-        editText.applyComment(AztecCommentSpan.Comment.MORE)
+        editText.toggleFormatting(TextFormat.FORMAT_MORE)
 
         Assert.assertEquals("$HTML_LIST_UNORDERED_SELECTED_1$HTML_COMMENT_MORE$HTML_LIST_UNORDERED_SELECTED_2", editText.toHtml())
     }
@@ -307,7 +307,7 @@ class AztecCommentTest() : AndroidTestCase() {
         val html = HTML_LIST_ORDERED + HTML_LIST_UNORDERED + HTML_QUOTE
         editText.fromHtml(html)
         editText.setSelection(2, 20) // select between second character of ordered list and second character of quote (includes newline characters)
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED_SELECTED_1$HTML_COMMENT_PAGE$HTML_QUOTE_SPLIT_2", editText.toHtml())
     }
@@ -325,7 +325,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(editText.length()) // select after list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED$HTML_COMMENT_PAGE<br>", editText.toHtml())
     }
@@ -343,7 +343,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(editText.length()) // select after quote
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_QUOTE$HTML_COMMENT_PAGE<br>", editText.toHtml())
     }
@@ -361,7 +361,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(editText.length()) // select after list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_LIST_UNORDERED$HTML_COMMENT_PAGE<br>", editText.toHtml())
     }
@@ -379,7 +379,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(0) // select before list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("<br>$HTML_COMMENT_PAGE$HTML_LIST_ORDERED", editText.toHtml())
     }
@@ -397,7 +397,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(0) // select before quote
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("<br>$HTML_COMMENT_PAGE$HTML_QUOTE", editText.toHtml())
     }
@@ -415,7 +415,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(0) // select before list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("<br>$HTML_COMMENT_PAGE$HTML_LIST_UNORDERED", editText.toHtml())
     }
@@ -434,7 +434,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(2) // select after second character in list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED_SPLIT_1$HTML_COMMENT_PAGE$HTML_LIST_ORDERED_SPLIT_2", editText.toHtml())
     }
@@ -453,7 +453,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(2) // select after second character in quote
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_QUOTE_SPLIT_1$HTML_COMMENT_PAGE$HTML_QUOTE_SPLIT_2", editText.toHtml())
     }
@@ -472,7 +472,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(2) // select after second character in list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_LIST_UNORDERED_SPLIT_1$HTML_COMMENT_PAGE$HTML_LIST_UNORDERED_SPLIT_2", editText.toHtml())
     }
@@ -491,7 +491,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_ORDERED)
         editText.setSelection(2, 4) // select between second and fourth character in list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_LIST_ORDERED_SELECTED_1$HTML_COMMENT_PAGE$HTML_LIST_ORDERED_SELECTED_2", editText.toHtml())
     }
@@ -510,7 +510,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_QUOTE)
         editText.setSelection(2, 4) // select between second and fourth character in quote
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_QUOTE_SELECTED_1$HTML_COMMENT_PAGE$HTML_QUOTE_SELECTED_2", editText.toHtml())
     }
@@ -529,7 +529,7 @@ class AztecCommentTest() : AndroidTestCase() {
 
         editText.fromHtml(HTML_LIST_UNORDERED)
         editText.setSelection(2, 4) // select between second and fourth character in list
-        editText.applyComment(AztecCommentSpan.Comment.PAGE)
+        editText.toggleFormatting(TextFormat.FORMAT_PAGE)
 
         Assert.assertEquals("$HTML_LIST_UNORDERED_SELECTED_1$HTML_COMMENT_PAGE$HTML_LIST_UNORDERED_SELECTED_2", editText.toHtml())
     }


### PR DESCRIPTION
This PR is an attempt at moving styling functionality from AztecText to separate modules and doing some light refactoring.  As a result AztecText shrunk almost three times, from 1.7k to 640 lines.

Apart from minor refactoring here and there:
- All the styling code was split and moved into four "Formatter" classes `BlockFormatter`,`InlineFormatter`, `LineBlockFormatter` and `LinkFormatter`, that all extend `AztecFormatter` which contains a couple of most commonly used shortcuts to editor properties (selection, editable text).
- Default style (quotes,lists,links) was moved to separate xml style, and passed from init() method directly to corresponding formatters.
- Link dialog was moved from toolbar to `AztecText`

This is not a final form of the project, and any ideas on it's structure and architecture are welcome :)