### PR TITLE
Issue/124 fixing comment in unknown

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -496,7 +496,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
 
     private void handleStartTag(String tag, Attributes attributes) {
         if (mUnknownTagLevel != 0) {
-            if(tag.equalsIgnoreCase("aztec_cursor")){
+            if (tag.equalsIgnoreCase("aztec_cursor")) {
                 handleCursor(mSpannableStringBuilder);
                 return;
             }
@@ -569,7 +569,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
     private void handleEndTag(String tag) {
         // Unknown tag previously detected
         if (mUnknownTagLevel != 0) {
-            if(tag.equalsIgnoreCase("aztec_cursor")){
+            if (tag.equalsIgnoreCase("aztec_cursor")) {
                 return; //already handled at start tag
             }
             // Swallow closing tag in current Unknown element
@@ -992,6 +992,15 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
 
     @Override
     public void comment(char[] chars, int start, int length) throws SAXException {
+        if (mUnknownTagLevel != 0) {
+            mUnknown.rawHtml.append("<!--");
+            for (int i = 0; i < length; i++) {
+                mUnknown.rawHtml.append(chars[i + start]);
+            }
+            mUnknown.rawHtml.append("-->");
+            return;
+        }
+
         String comment = new String(chars, start, length);
         int spanStart = mSpannableStringBuilder.length();
         mSpannableStringBuilder.append(comment);

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -12,7 +12,7 @@ object Format {
         val doc = Jsoup.parseBodyFragment(content)
 
         //remove newline around all non block elements
-        val newlineToTheLeft = replaceAll(doc.body().html(), "(?<!</?($block)>)\n<((?!/?($block)).*?)>", "<$2>")
+        val newlineToTheLeft = replaceAll(doc.body().html(), "(?<!</?($block)>)\n\\s*?<((?!/?($block)).*?)>", "<$2>")
         val newlineToTheRight = replaceAll(newlineToTheLeft, "<(/?(?!$block).)>\n(?!</?($block)>)", "<$1>")
         val fixBrNewlines = replaceAll(newlineToTheRight, "(<br>)(?!\n)", "$1\n")
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -37,6 +37,7 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_STRIKETHROUGH = "<s>Strikethrough</s>" // <s> or <strike> or <del>
     private val HTML_UNDERLINE = "<u>Underline</u><br><br>"
     private val HTML_UNKNOWN = "<iframe class=\"classic\">Menu</iframe><br><br>"
+    private val HTML_COMMENT_INSIDE_UNKNOWN = "<unknown><!--more--></unknown>"
     private val HTML_NESTED_MIXED =
             "<span></span>" +
                     "<div class=\"first\">" +
@@ -775,6 +776,22 @@ class AztecParserTest : AndroidTestCase() {
         )
         val html = mParser.toHtml(input)
         val output = mParser.fromHtml(html, context)
+        Assert.assertEquals(input, output)
+    }
+
+    /**
+     * Parse comment tag nested inside unknown HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlCommentInsideUnknown_isEqual() {
+        val input =
+                HTML_COMMENT_INSIDE_UNKNOWN
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 }


### PR DESCRIPTION
### Fix #124 

Instead of applying comment span when parser is inside unknown html, just append html of the comment to it.

Also, modified the source formatting regex to include possible space when looking for newline characters.

