### PR TITLE
Issue/118 fixing order of nested elements

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -105,22 +105,23 @@ class AztecParser {
         }
     }
 
+    data class SpanToReset(val span: AztecSpan, val start: Int, val end: Int)
+
     fun adjustNestedSpanOrder(spanned: Editable) {
         spanned.getSpans(0, spanned.length, AztecSpan::class.java).forEach { outsideSpan ->
             val spanStart = spanned.getSpanStart(outsideSpan)
             val spanEnd = spanned.getSpanEnd(outsideSpan)
 
-            val spansToReset = ArrayList<AztecSpan>()
-
+            val spansToReset = ArrayList<SpanToReset>()
 
             spanned.getSpans(spanStart, spanEnd, AztecSpan::class.java).forEach innerLoop@ { nestedSpan ->
                 if (outsideSpan == nestedSpan) return@innerLoop
 
                 val nestedSpanStart = spanned.getSpanStart(nestedSpan)
                 val nestedSpanEnd = spanned.getSpanEnd(nestedSpan)
-                if (nestedSpanStart == spanStart && nestedSpanEnd == spanEnd) {
+                if (nestedSpanStart == spanStart || nestedSpanEnd == spanEnd) {
                     spanned.removeSpan(nestedSpan)
-                    spansToReset.add(nestedSpan)
+                    spansToReset.add(SpanToReset(nestedSpan, nestedSpanStart, nestedSpanEnd))
                 }
             }
 
@@ -128,8 +129,8 @@ class AztecParser {
                 spanned.removeSpan(outsideSpan)
                 spanned.setSpan(outsideSpan, spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 
-                spansToReset.forEach { nestedSpan ->
-                    spanned.setSpan(nestedSpan, spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                spansToReset.forEach { spanToReset ->
+                    spanned.setSpan(spanToReset.span, spanToReset.start, spanToReset.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                 }
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -41,8 +41,9 @@ class AztecParser {
         val tidySource = tidy(source)
         val spanned = SpannableStringBuilder(Html.fromHtml(tidySource, null, AztecTagHandler(), context))
 
-        fixBlockElementsRanges(spanned)
         adjustNestedSpanOrder(spanned)
+        fixBlockElementsRanges(spanned)
+
 
         return spanned
     }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -1,7 +1,6 @@
 package org.wordpress.aztec
 
 import android.app.Activity
-import android.widget.ToggleButton
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -9,8 +8,6 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricGradleTestRunner
 import org.robolectric.annotation.Config
-import org.wordpress.aztec.source.SourceViewEditText
-import org.wordpress.aztec.toolbar.AztecToolbar
 
 /**
  * Testing attribute preservation for supported HTML elements
@@ -31,8 +28,7 @@ class AttributeTest {
         private val BOLD_NO_ATTRS = "<b>Bold</b>"
         private val ITALIC = "<i i=\"I\">Italic</i>"
         private val UNDERLINE = "<u j=\"J\">Underline</u>"
-        private val NESTED = "<i a=\"A\"><b><u class=\"klass\">Nested</u></b><i>"
-        private val NESTED_REVERSED = "<u class=\"klass\"><b><i a=\"A\">Nested</i></b></u>"
+        private val NESTED = "<i a=\"A\"><b><u class=\"klass\">Nested</u></b></i>"
         private val STRIKETHROUGH = "<s class=\"test\">Strikethrough</s>" // <s> or <strike> or <del>
         private val ORDERED = "<ol l=\"L\"><li>Ordered</li></ol>"
         private val UNORDERED = "<ul m=\"M\"><li>Unordered</li></ul>"
@@ -108,10 +104,9 @@ class AttributeTest {
     @Throws(Exception::class)
     fun nestedAttributes() {
         val input = NESTED
-        val expected = NESTED_REVERSED
         editText.fromHtml(input)
         val output = editText.toHtml()
-        Assert.assertEquals(expected, output)
+        Assert.assertEquals(input, output)
     }
 
     @Test
@@ -252,7 +247,7 @@ class AttributeTest {
     @Throws(Exception::class)
     fun mixedAttributes() {
         val input = MIXED + NESTED
-        val expected = MIXED + NESTED_REVERSED
+        val expected = MIXED + NESTED
         editText.fromHtml(input)
         val output = editText.toHtml()
         Assert.assertEquals(expected, output)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -61,7 +61,7 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_NESTED_INTERLEAVING =
             "<div><div><div><span></span><div></div><span></span></div></div></div><br>" +
                     "<div><span>1</span><br><div>2</div>3<span></span><br>4</div><br><br>5<br><br><div></div>"
-
+    private val HTML_NESTED_INLINE = "<u><i><b>Nested</b></i></u>"
     private val HTML_HIDDEN_WITH_NO_TEXT = "<br><br><div></div><br><br>"
 
     private val SPAN_BOLD = "Bold\n\n"
@@ -867,6 +867,21 @@ class AztecParserTest : AndroidTestCase() {
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlLineBreakBetweenHeaders_isEqual() {
         val input = HTML_SINGLE_HEADER + "<br>" + HTML_SINGLE_HEADER
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
+
+    /**
+     * Parse HTML of nested inline text style to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlNestedInlineStyles_isEqual() {
+        val input = HTML_NESTED_INLINE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)


### PR DESCRIPTION
Fixes #118

The problem was caused by the way we parse html. When going through something like this `<b><i>bold italic</i> bold</b>` the first span that will be added to text is italic, because we add span when hitting the end tag, and `</i>` comes before `</b>`. This affected all the tags that have at least one shared start/end index.

What we are doing to fix it, is after html->span parsing is over, we are going through all the spans and resetting nested elements in correct order.

This PR also fixed the issue with nested block elements being reversed in visual mode.