### PR TITLE
Issue/139 fix newline handling around block elements

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -110,11 +110,13 @@ class AztecParser {
             val spanStart = text.getSpanStart(it)
             val spanEnd = text.getSpanEnd(it)
 
-            val followingBlockElement = spanStart - 2 > 0 && text.getSpans(spanStart - 2, spanStart - 2, AztecLineBlockSpan::class.java).isNotEmpty()
+            val lookbehindRange = if (spanStart > 0 && text[spanStart - 1] == '\n') spanStart - 1 else spanStart - 2
+            val isFollowingBlockElement = lookbehindRange > 0 && text.getSpans(lookbehindRange, lookbehindRange, AztecLineBlockSpan::class.java).isNotEmpty()
 
-            if (spanStart > 2 && text[spanStart - 1] == '\n' && text[spanStart - 2] != '\n' && !followingBlockElement) {
+            if (spanStart >= 2 && !isFollowingBlockElement &&
+                    text.getSpans(spanStart - 2, spanStart - 2, BlockElementLinebreak::class.java).isEmpty()) {
                 text.setSpan(BlockElementLinebreak(), spanStart - 1, spanStart, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            } else if (spanStart > 2 && text[spanStart - 1] == '\n' && text[spanStart - 2] == '\n' && followingBlockElement) {
+            } else if (spanStart > 2 && text[spanStart - 1] == '\n' && text[spanStart - 2] == '\n' && isFollowingBlockElement) {
                 //Look back and adjust position any unnecessary BlockElementLinebreak's
                 text.getSpans(spanStart - 1, spanStart - 1, BlockElementLinebreak::class.java).forEach {
                     text.setSpan(it, text.getSpanStart(it) - 1, text.getSpanEnd(it) - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -93,7 +93,7 @@ class AztecTagHandler : Html.TagHandler {
         if (output.isNotEmpty()) {
             val nestedInBlockElement = isNestedInBlockElement(output, opening)
 
-            val followingBlockElement = opening && output[output.length-1] == '\n'
+            val followingBlockElement = opening && output[output.length-1] == '\n' &&
                     output.getSpans(output.length - 1, output.length - 1, AztecLineBlockSpan::class.java).isNotEmpty()
 
             if (!followingBlockElement && !nestedInBlockElement && (output[output.length - 1] != '\n' || opening)) {

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -27,7 +27,6 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_ORDERED_LIST_WITH_QUOTE = "<ol><li><blockquote>Quote</blockquote></li></ol>"
     private val HTML_COMMENT = "<!--Comment--><br><br>"
     private val HTML_SINGLE_HEADER = "<h1>Heading 1</h1>"
-    private val HTML_HEADER_SURROUNDED_BY_TEXT = "text<h1>Heading 1</h1>text"
     private val HTML_HEADER = "<h1>Heading 1</h1><br><br><h2>Heading 2</h2><br><br><h3>Heading 3</h3><br><br><h4>Heading 4</h4><br><br><h5>Heading 5</h5><br><br><h6>Heading 6</h6><br><br>"
     private val HTML_ITALIC = "<i>Italic</i><br><br>"
     private val HTML_LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a>"
@@ -229,6 +228,53 @@ class AztecParserTest : AndroidTestCase() {
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(HTML_ORDERED_LIST, output)
+    }
+
+    /**
+     * Parse ordered list surrounded text from HTML to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlOrderedListSurroundedByText_isEqual() {
+        val input = "1" + HTML_ORDERED_LIST + "2"
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
+
+
+    /**
+     * Parse ordered list surrounded text from HTML to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlOrderedListSurroundedByNewlineAndText_isEqual() {
+        val input = "1<br>$HTML_ORDERED_LIST<br>1"
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
+
+
+    /**
+     * Parse ordered lists with text inbetween from HTML to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlListsWithTextInbetween_isEqual() {
+        val input = HTML_ORDERED_LIST + "1" + HTML_ORDERED_LIST
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
     }
 
     /**
@@ -821,7 +867,7 @@ class AztecParserTest : AndroidTestCase() {
     @Test
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlSingleHeaderSurroundedByText_isEqual() {
-        val input = HTML_HEADER_SURROUNDED_BY_TEXT
+        val input = "1" + HTML_SINGLE_HEADER + "1"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/BlockElementsTest.kt
@@ -60,7 +60,7 @@ class BlockElementsTest {
         editText.append("quote")
         editText.setSelection(editText.length())
         editText.toggleFormatting(TextFormat.FORMAT_QUOTE)
-        Assert.assertEquals("some text<br><br><blockquote>quote</blockquote>", editText.toHtml())
+        Assert.assertEquals("some text<br><blockquote>quote</blockquote>", editText.toHtml())
         editText.setSelection(editText.length())
         editText.append("\n")
         editText.append("\n")
@@ -73,7 +73,7 @@ class BlockElementsTest {
         editText.append("\n")
         editText.append("some text")
 
-        Assert.assertEquals("some text<br><br><blockquote>quote</blockquote><br><ul><li>list</li></ul><br>some text", editText.toHtml())
+        Assert.assertEquals("some text<br><blockquote>quote</blockquote><br><ul><li>list</li></ul><br>some text", editText.toHtml())
     }
 
 }


### PR DESCRIPTION
Fixes #139 

Looks like I (again) messed up newline parsing around bloc elements in previous PR.

This PR hopefully fixes the issues. Should also help with #138