### PR TITLE
Issue/151 fixing single character headers parsing

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -96,7 +96,7 @@ class AztecTagHandler : Html.TagHandler {
 
             if (!followingBlockElement && !nestedInBlockElement && (output[output.length - 1] != '\n' || opening)) {
                 output.append("\n")
-            } else if (span is AztecQuoteSpan && !opening && nestedInBlockElement) {
+            } else if (span !is AztecListSpan && !opening && nestedInBlockElement) {
                 output.append("\n")
             }
         }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -953,6 +953,21 @@ class AztecParserTest : AndroidTestCase() {
         Assert.assertEquals(input, output)
     }
 
+    /**
+     * Parse HTML of header with single character surounded by other headers to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlSingleCharHeaderSurroundedByHeaders_isEqual() {
+        val input = "<h1>Heading 1</h1><h2>2</h2><h3>Heading 3</h3>"
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
+
     @Test
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlOrderedListWithTrailingEmptyItem_isEqual() {


### PR DESCRIPTION
Fixes #151 

To test:
Load this html into demo and make sure it looks as expected:

`<h1>Heading 1</h1><h2>2</h2><h3>Heading 3</h3>`

Should look something like this:

> <h1>Heading 1</h1><h2>2</h2><h3>Heading 3</h3>