### PR TITLE
Mark All Block Formats in Selection as Active in Toolbar

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -392,16 +392,16 @@ class AztecText : EditText, TextWatcher {
     override fun beforeTextChanged(text: CharSequence, start: Int, count: Int, after: Int) {
         if (!isViewInitialized) return
 
-        if (selectionEnd < text.length && text[selectionEnd] == Constants.ZWJ_CHAR)
+        if (selectionEnd < text.length && text[selectionEnd] == Constants.ZWJ_CHAR) {
             setSelection(selectionEnd + 1)
+        }
 
+        blockFormatter.carryOverDeletedListItemAttributes(count, start, text, this.text)
         inlineFormatter.carryOverInlineSpans(start, count, after)
 
         if (!isTextChangedListenerDisabled()) {
             history.beforeTextChanged(toFormattedHtml())
         }
-
-        blockFormatter.carryOverDeletedListItemAttributes(count, start, text, this.text)
     }
 
     override fun onTextChanged(text: CharSequence, start: Int, before: Int, count: Int) {
@@ -424,10 +424,9 @@ class AztecText : EditText, TextWatcher {
 
         blockFormatter.handleBlockStyling(text, textChangedEventDetails)
         inlineFormatter.handleInlineStyling(textChangedEventDetails)
+        lineBlockFormatter.handleLineBlockStyling(textChangedEventDetails)
 
         isMediaAdded = text.getSpans(0, text.length, AztecMediaSpan::class.java).isNotEmpty()
-
-        lineBlockFormatter.handleLineBlockStyling(textChangedEventDetails)
 
         if (textChangedEventDetails.count > 0 && text.isEmpty()) {
             onSelectionChanged(0, 0)
@@ -437,7 +436,6 @@ class AztecText : EditText, TextWatcher {
         blockFormatter.realignAttributesWhenAddingItem(text, textChangedEventDetails)
 
         history.handleHistory(this)
-
     }
 
     fun removeLeadingStyle(text: Editable, spanClass: Class<*>) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -322,9 +322,17 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                 continue
             }
 
-            if (lineStart <= selStart && selEnd <= lineEnd) {
-                list.add(i)
-            } else if (selStart <= lineStart && lineEnd <= selEnd) {
+            /**
+             * lineStart  >= selStart && selEnd   >= lineEnd // single line, current entirely selected OR
+             *                                                  multiple lines (before and/or after), current entirely selected
+             * lineStart  <= selEnd   && selEnd   <= lineEnd // single line, current partially or entirely selected OR
+             *                                                  multiple lines (after), current partially or entirely selected
+             * lineStart  <= selStart && selStart <= lineEnd // single line, current partially or entirely selected OR
+             *                                                  multiple lines (before), current partially or entirely selected
+             */
+            if ((lineStart >= selStart && selEnd >= lineEnd)
+                    || (lineStart <= selEnd && selEnd <= lineEnd)
+                    || (lineStart <= selStart && selStart <= lineEnd)) {
                 list.add(i)
             }
         }
@@ -364,9 +372,17 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                 continue
             }
 
-            if (lineStart <= selStart && selEnd <= lineEnd) {
-                list.add(i)
-            } else if (selStart <= lineStart && lineEnd <= selEnd) {
+            /**
+             * lineStart  >= selStart && selEnd   >= lineEnd // single line, current entirely selected OR
+             *                                                  multiple lines (before and/or after), current entirely selected
+             * lineStart  <= selEnd   && selEnd   <= lineEnd // single line, current partially or entirely selected OR
+             *                                                  multiple lines (after), current partially or entirely selected
+             * lineStart  <= selStart && selStart <= lineEnd // single line, current partially or entirely selected OR
+             *                                                  multiple lines (before), current partially or entirely selected
+             */
+            if ((lineStart >= selStart && selEnd >= lineEnd)
+                    || (lineStart <= selEnd && selEnd <= lineEnd)
+                    || (lineStart <= selStart && selStart <= lineEnd)) {
                 list.add(i)
             }
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -90,12 +90,12 @@ class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(
 
 
     fun handleInlineStyling(textChangedEvent: TextChangedEvent) {
+        //trailing styling
+        if (!editor.formattingHasChanged() || textChangedEvent.isNewLineButNotAtTheBeginning()) return
+
         //because we use SPAN_INCLUSIVE_INCLUSIVE for inline styles
         //we need to make sure unselected styles are not applied
         clearInlineStyles(textChangedEvent.inputStart, textChangedEvent.inputEnd, textChangedEvent.isNewLineButNotAtTheBeginning())
-
-        //trailing styling
-        if (!editor.formattingHasChanged() || textChangedEvent.isNewLineButNotAtTheBeginning()) return
 
         if (editor.formattingIsApplied()) {
             for (item in editor.selectedStyles) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -154,9 +154,17 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
                 continue
             }
 
-            if (lineStart <= selStart && selEnd <= lineEnd) {
-                list.add(i)
-            } else if (selStart <= lineStart && lineEnd <= selEnd) {
+            /**
+             * lineStart  >= selStart && selEnd   >= lineEnd // single line, current entirely selected OR
+             *                                                  multiple lines (before and/or after), current entirely selected
+             * lineStart  <= selEnd   && selEnd   <= lineEnd // single line, current partially or entirely selected OR
+             *                                                  multiple lines (after), current partially or entirely selected
+             * lineStart  <= selStart && selStart <= lineEnd // single line, current partially or entirely selected OR
+             *                                                  multiple lines (before), current partially or entirely selected
+             */
+            if ((lineStart >= selStart && selEnd >= lineEnd)
+                    || (lineStart <= selEnd && selEnd <= lineEnd)
+                    || (lineStart <= selStart && selStart <= lineEnd)) {
                 list.add(i)
             }
         }


### PR DESCRIPTION
### Fix
Mark all block formats including headings, lists, and quotes as active in the format toolbar if they are within the selected text as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/78.

### Test
1. Enter multiple heading, list, or quote.
2. Select multiple lines.
3. Notice all formats in selection are active.