### PR TITLE
Mark All Inline Formats in Selection as Active in Toolbar

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -399,6 +399,7 @@ class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(
             // Make sure no duplicate characters be added
             for (i in start..end - 1) {
                 val spans = editableText.getSpans(i, i + 1, AztecInlineSpan::class.java)
+
                 for (span in spans) {
                     if (isSameInlineSpanType(span, spanToCheck)) {
                         builder.append(editableText.subSequence(i, i + 1).toString())
@@ -407,9 +408,10 @@ class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(
                 }
             }
 
-            return editableText.subSequence(start, end).toString() == builder.toString()
-        }
+            val selectedText = editableText.subSequence(start, end).toString().replace("\n", "")
+            val styledText = builder.toString()
 
+            return !styledText.isEmpty() && selectedText.contains(styledText)
+        }
     }
 }
-

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -300,34 +300,44 @@ class AztecToolbarTest {
         //cursor is at bold text
         editText.setSelection(2)
         Assert.assertTrue(boldButton.isChecked)
-
+        Assert.assertFalse(italicButton.isChecked)
+        Assert.assertFalse(strikeThroughButton.isChecked)
 
         //cursor is at bold/italic text
         editText.setSelection(7)
         Assert.assertTrue(boldButton.isChecked)
         Assert.assertTrue(italicButton.isChecked)
+        Assert.assertFalse(strikeThroughButton.isChecked)
 
-        //bold text with mixed italic style is selected
+        //bold and bold/italic styles selected
         editText.setSelection(2, 7)
         Assert.assertTrue(boldButton.isChecked)
-        Assert.assertFalse(italicButton.isChecked)
+        Assert.assertTrue(italicButton.isChecked)
+        Assert.assertFalse(strikeThroughButton.isChecked)
 
-        //unstyled text selected
+        //cursor is at italic text
+        editText.setSelection(15)
+        Assert.assertFalse(boldButton.isChecked)
+        Assert.assertTrue(italicButton.isChecked)
+        Assert.assertFalse(strikeThroughButton.isChecked)
+
+        //cursor is at strikethrough text
         editText.setSelection(22)
         Assert.assertFalse(boldButton.isChecked)
         Assert.assertFalse(italicButton.isChecked)
         Assert.assertTrue(strikeThroughButton.isChecked)
 
-        //unstyled text selected
-        editText.setSelection(15)
+        //cursor is at unstyled text
+        editText.setSelection(28)
         Assert.assertFalse(boldButton.isChecked)
-        Assert.assertTrue(italicButton.isChecked)
+        Assert.assertFalse(italicButton.isChecked)
+        Assert.assertFalse(strikeThroughButton.isChecked)
 
         //whole text selected
         editText.setSelection(0, editText.length() - 1)
-        Assert.assertFalse(italicButton.isChecked)
-        Assert.assertFalse(boldButton.isChecked)
-        Assert.assertFalse(strikeThroughButton.isChecked)
+        Assert.assertTrue(boldButton.isChecked)
+        Assert.assertTrue(italicButton.isChecked)
+        Assert.assertTrue(strikeThroughButton.isChecked)
     }
 
     /**
@@ -338,18 +348,18 @@ class AztecToolbarTest {
      */
     @Test
     @Throws(Exception::class)
-    fun extendStyle() {
+    fun removeStyleItalicPartialSelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
 
         val selectedText = editText.text.substring(3, 5)
         Assert.assertEquals("di", selectedText) //sanity check
 
         editText.setSelection(3, 5)
-
         Assert.assertTrue(boldButton.isChecked)
-        italicButton.performClick()
+        Assert.assertTrue(italicButton.isChecked)
 
-        Assert.assertEquals("<b>bol</b><b><i>ditalic</i></b>", editText.toHtml())
+        italicButton.performClick()
+        Assert.assertEquals("<b>boldi</b><b><i>talic</i></b>", editText.toHtml())
     }
 
     /**
@@ -360,18 +370,18 @@ class AztecToolbarTest {
      */
     @Test
     @Throws(Exception::class)
-    fun extendStyleStrikethrough() {
+    fun removeStyleStrikethroughPartialSelection() {
         editText.fromHtml("<b>bold</b><b><del>strike</del></b>")
 
         val selectedText = editText.text.substring(3, 5)
         Assert.assertEquals("ds", selectedText) //sanity check
 
         editText.setSelection(3, 5)
-
         Assert.assertTrue(boldButton.isChecked)
-        strikeThroughButton.performClick()
+        Assert.assertTrue(strikeThroughButton.isChecked)
 
-        Assert.assertEquals("<b>bol</b><b><del>dstrike</del></b>", editText.toHtml())
+        strikeThroughButton.performClick()
+        Assert.assertEquals("<b>bolds</b><b><del>trike</del></b>", editText.toHtml())
     }
 
     /**
@@ -403,14 +413,13 @@ class AztecToolbarTest {
      */
     @Test
     @Throws(Exception::class)
-    fun extendStyleToWholeSelection() {
+    fun removeStyleFromWholeSelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
 
         editText.setSelection(0, editText.length())
 
         italicButton.performClick()
-
-        Assert.assertEquals("<b><i>bolditalic</i></b>", editText.toHtml())
+        Assert.assertEquals("<b>bolditalic</b>", editText.toHtml())
     }
 
     /**
@@ -420,20 +429,22 @@ class AztecToolbarTest {
      */
     @Test
     @Throws(Exception::class)
-    fun removeStyleFromWholeSelection() {
+    fun removeAndApplyStyleFromWholeSelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
 
         editText.setSelection(0, editText.length())
 
         boldButton.performClick()
-
         Assert.assertEquals("bold<i>italic</i>", editText.toHtml())
+
+        italicButton.performClick()
+        Assert.assertEquals("bolditalic", editText.toHtml())
 
         italicButton.performClick()
         Assert.assertEquals("<i>bolditalic</i>", editText.toHtml())
 
-        italicButton.performClick()
-        Assert.assertEquals("bolditalic", editText.toHtml())
+        boldButton.performClick()
+        Assert.assertEquals("<i><b>bolditalic</b></i>", editText.toHtml())
     }
 
     /**


### PR DESCRIPTION
### Fix
Mark all inline formats including bold, italic, and strikethrough as active in the format toolbar if they are within the selected text as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/155.

### Test
1. Enter multiple bold, italic, and strikethrough.
2. Select multiple lines.
3. Notice all formats in selection are active.