### PR TITLE
Issue/146 newline above blocks

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt
@@ -94,9 +94,8 @@ class AztecTagHandler : Html.TagHandler {
             val followingBlockElement = opening && output[output.length-1] == '\n' &&
                     output.getSpans(output.length - 1, output.length - 1, AztecLineBlockSpan::class.java).isNotEmpty()
 
-            if (!followingBlockElement && !nestedInBlockElement && (output[output.length - 1] != '\n' || opening)) {
-                output.append("\n")
-            } else if (span is AztecQuoteSpan && !opening && nestedInBlockElement) {
+            if ((!followingBlockElement && !nestedInBlockElement && output.last() != '\n') ||
+                    (span is AztecQuoteSpan && nestedInBlockElement && !opening)) {
                 output.append("\n")
             }
         }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AttributeTest.kt
@@ -43,6 +43,7 @@ class AttributeTest {
         private val LIST_WITH_NON_EMPTY_ITEMS = "<ol><li a=\"B\">ab</li><li c=\"C\">c</li></ol>"
         private val LIST_WITH_EMPTY_ITEMS = "a<ul><li a=\"A\"></li><li></li><li a=\"1\">1</li><li></li><li b=\"B\"></li></ul>b"
         private val LIST_WITH_EMPTY_ITEMS_WITH_LINE_BREAK = "a<br><ul><li></li><li a=\"1\">1</li><li></li></ul><br>b"
+        private val LIST_WITH_EMPTY_ITEMS_WITH_LINE_BREAK_PARSED = "a<ul><li></li><li a=\"1\">1</li><li></li></ul><br>b"
         private val SUB = "<sub i=\"I\">Sub</sub>"
         private val SUP = "<sup i=\"I\">Sup</sup>"
         private val FONT = "<font i=\"I\">Font</font>"
@@ -269,9 +270,10 @@ class AttributeTest {
     @Throws(Exception::class)
     fun listWithEmptyItemsAndLineBreakAfterItAttributes() {
         val input = LIST_WITH_EMPTY_ITEMS_WITH_LINE_BREAK
+        val parsed = LIST_WITH_EMPTY_ITEMS_WITH_LINE_BREAK_PARSED
         editText.fromHtml(input)
         val output = editText.toHtml()
-        Assert.assertEquals(input, output)
+        Assert.assertEquals(parsed, output)
     }
 
     @Test

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -30,6 +30,7 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_COMMENT = "<!--Comment--><br><br>"
     private val HTML_SINGLE_HEADER = "<h1>Heading 1</h1>"
     private val HTML_HEADER = "<h1>Heading 1</h1><br><br><h2>Heading 2</h2><br><br><h3>Heading 3</h3><br><br><h4>Heading 4</h4><br><br><h5>Heading 5</h5><br><br><h6>Heading 6</h6><br><br>"
+    private val HTML_HEADER_PARSED = "<h1>Heading 1</h1><br><h2>Heading 2</h2><br><h3>Heading 3</h3><br><h4>Heading 4</h4><br><h5>Heading 5</h5><br><h6>Heading 6</h6><br><br>"
     private val HTML_ITALIC = "<i>Italic</i><br><br>"
     private val HTML_LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a>"
     private val HTML_MORE = "<!--more-->"
@@ -40,28 +41,29 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_STRIKETHROUGH = "<s>Strikethrough</s>" // <s> or <strike> or <del>
     private val HTML_UNDERLINE = "<u>Underline</u><br><br>"
     private val HTML_UNKNOWN = "<iframe class=\"classic\">Menu</iframe><br><br>"
+    private val HTML_UNKNOWN_PARSED = "<iframe class=\"classic\">Menu</iframe><br>"
     private val HTML_COMMENT_INSIDE_UNKNOWN = "<unknown><!--more--></unknown>"
     private val HTML_NESTED_MIXED =
             "<span></span>" +
-                    "<div class=\"first\">" +
-                    "<div class=\"second\">" +
-                    "<div class=\"third\">" +
-                    "Div<br><span><b>b</b></span><br>Hidden" +
-                    "</div>" +
-                    "<div class=\"fourth\"></div>" +
-                    "<div class=\"fifth\"></div>" +
-                    "</div>" +
-                    "<span class=\"second last\"></span>" +
-                    "<span></span><div><div><div><span></span></div></div></div><div></div>" +
-                    "</div>" +
-                    "<br><br>"
+            "<div class=\"first\">" +
+            "<div class=\"second\">" +
+            "<div class=\"third\">" +
+            "Div<br><span><b>b</b></span><br>Hidden" +
+            "</div>" +
+            "<div class=\"fourth\"></div>" +
+            "<div class=\"fifth\"></div>" +
+            "</div>" +
+            "<span class=\"second last\"></span>" +
+            "<span></span><div><div><div><span></span></div></div></div><div></div>" +
+            "</div>" +
+            "<br><br>"
     private val HTML_NESTED_EMPTY_END = "1<span></span><div><div><div><span></span>a</div><div></div><div></div></div><span></span></div>"
     private val HTML_NESTED_EMPTY_START = "<span></span><div><div><div><span></span></div><div></div></div><span></span></div>1"
     private val HTML_NESTED_EMPTY = "<span></span><div><div><div><span></span></div></div></div><div></div>"
     private val HTML_NESTED_WITH_TEXT = "<div>1<div>2<div>3<span>4</span>5</div>6</div>7</div>"
     private val HTML_NESTED_INTERLEAVING =
             "<div><div><div><span></span><div></div><span></span></div></div></div><br>" +
-                    "<div><span>1</span><br><div>2</div>3<span></span><br>4</div><br><br>5<br><br><div></div>"
+            "<div><span>1</span><br><div>2</div>3<span></span><br>4</div><br><br>5<br><br><div></div>"
     private val HTML_NESTED_INLINE = "<u><i><b>Nested</b></i></u>"
     private val HTML_HIDDEN_WITH_NO_TEXT = "<br><br><div></div><br><br>"
 
@@ -87,8 +89,9 @@ class AztecParserTest : AndroidTestCase() {
     }
 
     /**
-     * Parse all text from HTML to span to HTML.  If input and output are equal with
-     * the same length and corresponding characters, [AztecParser] is correct.
+     * Parse all text from HTML to span to HTML.  If parsed and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.  When block elements
+     * replace preceding <br> with [BlockElementLinebreak], input will not equal output.
      *
      * @throws Exception
      */
@@ -97,27 +100,53 @@ class AztecParserTest : AndroidTestCase() {
     fun parseHtmlToSpanToHtmlAll_isEqual() {
         val input =
                 HTML_HEADER +
-                        HTML_BOLD +
-                        HTML_ITALIC +
-                        HTML_UNDERLINE +
-                        HTML_STRIKETHROUGH +
-                        HTML_BULLET +
-                        HTML_QUOTE +
-                        HTML_LINK +
-                        HTML_BULLET_WITH_QUOTE +
-                        HTML_UNKNOWN +
-                        HTML_QUOTE_WITH_BULLETS +
-                        HTML_COMMENT +
-                        HTML_NESTED_MIXED +
-                        HTML_NESTED_EMPTY_END +
-                        HTML_NESTED_EMPTY_START +
-                        HTML_NESTED_EMPTY +
-                        HTML_NESTED_WITH_TEXT +
-                        HTML_NESTED_INTERLEAVING
+                HTML_BOLD +
+                HTML_ITALIC +
+                HTML_UNDERLINE +
+                HTML_STRIKETHROUGH +
+                HTML_ORDERED_LIST +
+                HTML_NUMBERED_LIST_WITH_EMPTY_ITEM +
+//                HTML_LIST_ORDERED_WITH_QUOTE +
+                HTML_BULLET +
+                HTML_BULLET_LIST_WITH_EMPTY_ITEM +
+//                HTML_LIST_UNORDERED_WITH_QUOTE +
+                HTML_QUOTE +
+                HTML_LINK +
+                HTML_UNKNOWN +
+                HTML_COMMENT +
+                HTML_NESTED_MIXED +
+                HTML_NESTED_EMPTY_END +
+                HTML_NESTED_EMPTY_START +
+                HTML_NESTED_EMPTY +
+                HTML_NESTED_WITH_TEXT +
+                HTML_NESTED_INTERLEAVING
+
+        val parsed =
+                HTML_HEADER_PARSED +
+                HTML_BOLD +
+                HTML_ITALIC +
+                HTML_UNDERLINE +
+                HTML_STRIKETHROUGH +
+                HTML_ORDERED_LIST +
+                HTML_NUMBERED_LIST_WITH_EMPTY_ITEM +
+//                HTML_LIST_ORDERED_WITH_QUOTE +
+                HTML_BULLET +
+                HTML_BULLET_LIST_WITH_EMPTY_ITEM +
+//                HTML_LIST_UNORDERED_WITH_QUOTE +
+                HTML_QUOTE +
+                HTML_LINK +
+                HTML_UNKNOWN_PARSED +
+                HTML_COMMENT +
+                HTML_NESTED_MIXED +
+                HTML_NESTED_EMPTY_END +
+                HTML_NESTED_EMPTY_START +
+                HTML_NESTED_EMPTY +
+                HTML_NESTED_WITH_TEXT +
+                HTML_NESTED_INTERLEAVING
 
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
-        Assert.assertEquals(input, output)
+        Assert.assertEquals(parsed, output)
     }
 
     /**
@@ -247,22 +276,22 @@ class AztecParserTest : AndroidTestCase() {
         Assert.assertEquals(input, output)
     }
 
-
     /**
-     * Parse ordered list surrounded text from HTML to span to HTML.  If input and output are equal with
-     * the same length and corresponding characters, [AztecParser] is correct.
+     * Parse ordered list surrounded text from HTML to span to HTML.  If parsed and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.  When block elements
+     * replace preceding <br> with [BlockElementLinebreak], input will not equal output.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlOrderedListSurroundedByNewlineAndText_isEqual() {
-        val input = "1<br>$HTML_ORDERED_LIST<br>1"
+    fun parseHtmlToSpanToHtmlListOrderedSurroundedByNewlineAndText_isEqual() {
+        val input = "1<br>$HTML_ORDERED_LIST<br>2"
+        val parsed = "1$HTML_ORDERED_LIST<br>2"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
-        Assert.assertEquals(input, output)
+        Assert.assertEquals(parsed, output)
     }
-
 
     /**
      * Parse ordered lists with text inbetween from HTML to span to HTML.  If input and output are equal with
@@ -296,8 +325,9 @@ class AztecParserTest : AndroidTestCase() {
     }
 
     /**
-     * Parse heading text from HTML to span to HTML.  If input and output are equal with
-     * the same length and corresponding characters, [AztecParser] is correct.
+     * Parse heading text from HTML to span to HTML.  If parsed and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.  When block elements
+     * replace preceding <br> with [BlockElementLinebreak], input will not equal output.
      *
      * @throws Exception
      */
@@ -306,9 +336,11 @@ class AztecParserTest : AndroidTestCase() {
     fun parseHtmlToSpanToHtmlHeading_isEqual() {
         val input =
                 HTML_HEADER
+        val parsed =
+                HTML_HEADER_PARSED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
-        Assert.assertEquals(input, output)
+        Assert.assertEquals(parsed, output)
     }
 
     /**
@@ -628,15 +660,14 @@ class AztecParserTest : AndroidTestCase() {
     fun parseSpanToHtmlToSpanAll_isEqual() {
         val input = SpannableString(
                 SPAN_HEADER +
-                        SPAN_BOLD +
-                        SPAN_ITALIC +
-                        SPAN_UNDERLINE +
-                        SPAN_STRIKETHROUGH +
-                        SPAN_BULLET +
-                        SPAN_QUOTE +
-                        SPAN_LINK +
-                        SPAN_UNKNOWN +
-                        SPAN_COMMENT
+                SPAN_BOLD +
+                SPAN_ITALIC +
+                SPAN_UNDERLINE +
+                SPAN_STRIKETHROUGH +
+                SPAN_QUOTE +
+                SPAN_LINK +
+                SPAN_UNKNOWN +
+                SPAN_COMMENT
         )
         val html = mParser.toHtml(input)
         val output = mParser.fromHtml(html, context)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -28,9 +28,9 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_LIST_UNORDERED_WITH_QUOTE = "<ul><li><blockquote>Unordered Quote</blockquote></li></ul>"
     private val HTML_LIST_UNORDERED_WITH_WHITE_SPACE = "<ul><li>Unordered<br></br></li></ul>"
     private val HTML_COMMENT = "<!--Comment--><br><br>"
-    private val HTML_SINGLE_HEADER = "<h1>Heading 1</h1>"
-    private val HTML_HEADER = "<h1>Heading 1</h1><br><br><h2>Heading 2</h2><br><br><h3>Heading 3</h3><br><br><h4>Heading 4</h4><br><br><h5>Heading 5</h5><br><br><h6>Heading 6</h6><br><br>"
-    private val HTML_HEADER_PARSED = "<h1>Heading 1</h1><br><h2>Heading 2</h2><br><h3>Heading 3</h3><br><h4>Heading 4</h4><br><h5>Heading 5</h5><br><h6>Heading 6</h6><br><br>"
+    private val HTML_HEADING_ALL = "<h1>Heading 1</h1><br><br><h2>Heading 2</h2><br><br><h3>Heading 3</h3><br><br><h4>Heading 4</h4><br><br><h5>Heading 5</h5><br><br><h6>Heading 6</h6><br><br>"
+    private val HTML_HEADING_ALL_PARSED = "<h1>Heading 1</h1><br><h2>Heading 2</h2><br><h3>Heading 3</h3><br><h4>Heading 4</h4><br><h5>Heading 5</h5><br><h6>Heading 6</h6><br><br>"
+    private val HTML_HEADING_ONE = "<h1>Heading 1</h1>"
     private val HTML_ITALIC = "<i>Italic</i><br><br>"
     private val HTML_LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a>"
     private val HTML_MORE = "<!--more-->"
@@ -70,7 +70,7 @@ class AztecParserTest : AndroidTestCase() {
     private val SPAN_BOLD = "Bold\n\n"
     private val SPAN_LIST_ORDERED = "Ordered\n\n"
     private val SPAN_COMMENT = "Comment\n\n"
-    private val SPAN_HEADER = "Heading 1\n\nHeading 2\n\nHeading 3\n\nHeading 4\n\nHeading 5\n\nHeading 6\n\n"
+    private val SPAN_HEADING = "Heading 1\n\nHeading 2\n\nHeading 3\n\nHeading 4\n\nHeading 5\n\nHeading 6\n\n"
     private val SPAN_ITALIC = "Italic\n\n"
     private val SPAN_LINK = "Link\n\n"
     private val SPAN_MORE = "more\n\n"
@@ -99,7 +99,7 @@ class AztecParserTest : AndroidTestCase() {
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlAll_isEqual() {
         val input =
-                HTML_HEADER +
+                HTML_HEADING_ALL +
                 HTML_BOLD +
                 HTML_ITALIC +
                 HTML_UNDERLINE +
@@ -122,7 +122,7 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_NESTED_INTERLEAVING
 
         val parsed =
-                HTML_HEADER_PARSED +
+                HTML_HEADING_ALL_PARSED +
                 HTML_BOLD +
                 HTML_ITALIC +
                 HTML_UNDERLINE +
@@ -323,13 +323,13 @@ class AztecParserTest : AndroidTestCase() {
         var parsed: String
         var span: SpannableString
 
-        input = "<br>$HTML_SINGLE_HEADER"
+        input = "<br>$HTML_HEADING_ONE"
         span = SpannableString(mParser.fromHtml(input, context))
         Assert.assertEquals("\nHeading 1", span.toString())
         output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
 
-        input = "Text<br>$HTML_SINGLE_HEADER"
+        input = "Text<br>$HTML_HEADING_ONE"
         parsed = input.replace("<br>", "")
         span = SpannableString(mParser.fromHtml(input, context))
         output = mParser.toHtml(span)
@@ -399,9 +399,9 @@ class AztecParserTest : AndroidTestCase() {
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlHeading_isEqual() {
         val input =
-                HTML_HEADER
+                HTML_HEADING_ALL
         val parsed =
-                HTML_HEADER_PARSED
+                HTML_HEADING_ALL_PARSED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(parsed, output)
@@ -723,7 +723,7 @@ class AztecParserTest : AndroidTestCase() {
     @Throws(Exception::class)
     fun parseSpanToHtmlToSpanAll_isEqual() {
         val input = SpannableString(
-                SPAN_HEADER +
+                SPAN_HEADING +
                 SPAN_BOLD +
                 SPAN_ITALIC +
                 SPAN_UNDERLINE +
@@ -799,7 +799,7 @@ class AztecParserTest : AndroidTestCase() {
     @Throws(Exception::class)
     fun parseSpanToHtmlToSpanHeading_isEqual() {
         val input = SpannableString(
-                SPAN_HEADER
+                SPAN_HEADING
         )
         val html = mParser.toHtml(input)
         val output = mParser.fromHtml(html, context)
@@ -959,75 +959,75 @@ class AztecParserTest : AndroidTestCase() {
     }
 
     /**
-     * Parse single header HTML to span to HTML.  If input and output are equal with
+     * Parse single heading HTML to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlSingleHeader_isEqual() {
-        val input = HTML_SINGLE_HEADER
+    fun parseHtmlToSpanToHtmlSingleHeading_isEqual() {
+        val input = HTML_HEADING_ONE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 
     /**
-     * Parse HTML of header surrounded by text to span to HTML.  If input and output are equal with
+     * Parse HTML of heading surrounded by text to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlSingleHeaderSurroundedByText_isEqual() {
-        val input = "1" + HTML_SINGLE_HEADER + "1"
+    fun parseHtmlToSpanToHtmlSingleHeadingSurroundedByText_isEqual() {
+        val input = "1" + HTML_HEADING_ONE + "1"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 
     /**
-     * Parse HTML of header surrounded by list to span to HTML.  If input and output are equal with
+     * Parse HTML of heading surrounded by list to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlHeaderSurroundedByList_isEqual() {
-        val input = HTML_LIST_ORDERED + HTML_SINGLE_HEADER + HTML_LIST_ORDERED
+    fun parseHtmlToSpanToHtmlHeadingSurroundedByList_isEqual() {
+        val input = HTML_LIST_ORDERED + HTML_HEADING_ONE + HTML_LIST_ORDERED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 
     /**
-     * Parse HTML of header surrounded by quote to span to HTML.  If input and output are equal with
+     * Parse HTML of heading surrounded by quote to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlHeaderSurroundedByQuote_isEqual() {
-        val input = HTML_QUOTE + HTML_SINGLE_HEADER + HTML_QUOTE
+    fun parseHtmlToSpanToHtmlHeadingSurroundedByQuote_isEqual() {
+        val input = HTML_QUOTE + HTML_HEADING_ONE + HTML_QUOTE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 
     /**
-     * Parse HTML of header surrounded by quote to span to HTML.  If input and output are equal with
+     * Parse HTML of heading surrounded by quote to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlLineBreakBetweenHeaders_isEqual() {
-        val input = HTML_SINGLE_HEADER + "<br>" + HTML_SINGLE_HEADER
+    fun parseHtmlToSpanToHtmlLineBreakBetweenHeadings_isEqual() {
+        val input = HTML_HEADING_ONE + "<br>" + HTML_HEADING_ONE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -19,15 +19,14 @@ import org.robolectric.annotation.Config
 class AztecParserTest : AndroidTestCase() {
     private var mParser = AztecParser()
     private val HTML_BOLD = "<b>Bold</b><br><br>"
-    private val HTML_BULLET = "<ul><li>Bullet</li></ul>"
-    private val HTML_BULLET_WITH_WHITE_SPACE = "<ul><li>Bullet<br></br></li></ul>"
-    private val HTML_BULLET_LIST_WITH_EMPTY_ITEM = "<ul><li>item</li><li></li><li>item 2</li></ul>"
-    private val HTML_NUMBERED_LIST = "<ol><li>Ordered</li></ol>"
-    private val HTML_NUMBERED_LIST_WITH_EMPTY_ITEM = "<ol><li>item</li><li></li><li>item 2</li></ol>"
-    private val HTML_BULLET_WITH_QUOTE = "<ul><li><blockquote>Quote</blockquote></li></ul>"
-    private val HTML_ORDERED_LIST = "<ol><li>Ordered item</li></ol>"
-    private val HTML_ORDERED_LIST_WITH_WHITE_SPACE = "<ol><li>Ordered item<br></br></li></ol>"
-    private val HTML_ORDERED_LIST_WITH_QUOTE = "<ol><li><blockquote>Quote</blockquote></li></ol>"
+    private val HTML_LIST_ORDERED = "<ol><li>Ordered</li></ol>"
+    private val HTML_LIST_ORDERED_WITH_EMPTY_ITEM = "<ol><li>Ordered 1</li><li></li><li>Ordered 2</li></ol>"
+    private val HTML_LIST_ORDERED_WITH_QUOTE = "<ol><li><blockquote>Ordered Quote</blockquote></li></ol>"
+    private val HTML_LIST_ORDERED_WITH_WHITE_SPACE = "<ol><li>Ordered<br></br></li></ol>"
+    private val HTML_LIST_UNORDERED = "<ul><li>Unordered</li></ul>"
+    private val HTML_LIST_UNORDERED_WITH_EMPTY_ITEM = "<ul><li>Unordered 1</li><li></li><li>Unordered 2</li></ul>"
+    private val HTML_LIST_UNORDERED_WITH_QUOTE = "<ul><li><blockquote>Unordered Quote</blockquote></li></ul>"
+    private val HTML_LIST_UNORDERED_WITH_WHITE_SPACE = "<ul><li>Unordered<br></br></li></ul>"
     private val HTML_COMMENT = "<!--Comment--><br><br>"
     private val HTML_SINGLE_HEADER = "<h1>Heading 1</h1>"
     private val HTML_HEADER = "<h1>Heading 1</h1><br><br><h2>Heading 2</h2><br><br><h3>Heading 3</h3><br><br><h4>Heading 4</h4><br><br><h5>Heading 5</h5><br><br><h6>Heading 6</h6><br><br>"
@@ -37,8 +36,8 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_MORE = "<!--more-->"
     private val HTML_PAGE = "<!--nextpage-->"
     private val HTML_QUOTE = "<blockquote>Quote</blockquote>"
+    private val HTML_QUOTE_WITH_LIST_ORDERED = "<blockquote><ol><li>Ordered</li></ol></blockquote>"
     private val HTML_QUOTE_WITH_WHITE_SPACE = "<blockquote>Quote<br><br></br></blockquote>"
-    private val HTML_QUOTE_WITH_BULLETS = "<blockquote><ul><li>Bullet</li></ul></blockquote>"
     private val HTML_STRIKETHROUGH = "<s>Strikethrough</s>" // <s> or <strike> or <del>
     private val HTML_UNDERLINE = "<u>Underline</u><br><br>"
     private val HTML_UNKNOWN = "<iframe class=\"classic\">Menu</iframe><br><br>"
@@ -69,7 +68,7 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_HIDDEN_WITH_NO_TEXT = "<br><br><div></div><br><br>"
 
     private val SPAN_BOLD = "Bold\n\n"
-    private val SPAN_BULLET = "Bullet\n\n"
+    private val SPAN_LIST_ORDERED = "Ordered\n\n"
     private val SPAN_COMMENT = "Comment\n\n"
     private val SPAN_HEADER = "Heading 1\n\nHeading 2\n\nHeading 3\n\nHeading 4\n\nHeading 5\n\nHeading 6\n\n"
     private val SPAN_ITALIC = "Italic\n\n"
@@ -105,11 +104,11 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_ITALIC +
                 HTML_UNDERLINE +
                 HTML_STRIKETHROUGH +
-                HTML_ORDERED_LIST +
-                HTML_NUMBERED_LIST_WITH_EMPTY_ITEM +
+                HTML_LIST_ORDERED +
+                HTML_LIST_ORDERED_WITH_EMPTY_ITEM +
 //                HTML_LIST_ORDERED_WITH_QUOTE +
-                HTML_BULLET +
-                HTML_BULLET_LIST_WITH_EMPTY_ITEM +
+                HTML_LIST_UNORDERED +
+                HTML_LIST_UNORDERED_WITH_EMPTY_ITEM +
 //                HTML_LIST_UNORDERED_WITH_QUOTE +
                 HTML_QUOTE +
                 HTML_LINK +
@@ -128,11 +127,11 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_ITALIC +
                 HTML_UNDERLINE +
                 HTML_STRIKETHROUGH +
-                HTML_ORDERED_LIST +
-                HTML_NUMBERED_LIST_WITH_EMPTY_ITEM +
+                HTML_LIST_ORDERED +
+                HTML_LIST_ORDERED_WITH_EMPTY_ITEM +
 //                HTML_LIST_ORDERED_WITH_QUOTE +
-                HTML_BULLET +
-                HTML_BULLET_LIST_WITH_EMPTY_ITEM +
+                HTML_LIST_UNORDERED +
+                HTML_LIST_UNORDERED_WITH_EMPTY_ITEM +
 //                HTML_LIST_UNORDERED_WITH_QUOTE +
                 HTML_QUOTE +
                 HTML_LINK +
@@ -167,51 +166,51 @@ class AztecParserTest : AndroidTestCase() {
     }
 
     /**
-     * Parse bullet text from HTML to span to HTML.  If input and output are equal with
+     * Parse unordered list text from HTML to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlBullet_isEqual() {
+    fun parseHtmlToSpanToHtmlListUnordered_isEqual() {
         val input =
-                HTML_BULLET
+                HTML_LIST_UNORDERED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 
     /**
-     * Parse bullets with quotes from HTML to span to HTML.  If input and output are equal with
+     * Parse unordered list with quote from HTML to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlBulletsWithQuotes_isEqual() {
+    fun parseHtmlToSpanToHtmlListUnorderedWithQuote_isEqual() {
         val input =
-                HTML_BULLET_WITH_QUOTE
+                HTML_LIST_UNORDERED_WITH_QUOTE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 
     /**
-     * Parse bullet with white space text from HTML to span to HTML.  If input and output are equal with
+     * Parse unordered list with white space text from HTML to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlBulletWhiteSpace_isEqual() {
+    fun parseHtmlToSpanToHtmlListUnorderedWhiteSpace_isEqual() {
         val input =
-                HTML_BULLET_WITH_WHITE_SPACE
+                HTML_LIST_UNORDERED_WITH_WHITE_SPACE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
-        Assert.assertEquals(HTML_BULLET, output)
+        Assert.assertEquals(HTML_LIST_UNORDERED, output)
     }
 
     /**
@@ -222,25 +221,25 @@ class AztecParserTest : AndroidTestCase() {
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlOrderedList_isEqual() {
+    fun parseHtmlToSpanToHtmlListOrdered_isEqual() {
         val input =
-                HTML_ORDERED_LIST
+                HTML_LIST_ORDERED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
     }
 
     /**
-     * Parse ordered lists with quotes from HTML to span to HTML.  If input and output are equal with
+     * Parse ordered lists with quote from HTML to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlOrderedListsWithQuotes_isEqual() {
+    fun parseHtmlToSpanToHtmlListOrderedWithQuote_isEqual() {
         val input =
-                HTML_ORDERED_LIST_WITH_QUOTE
+                HTML_LIST_ORDERED_WITH_QUOTE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
@@ -254,12 +253,12 @@ class AztecParserTest : AndroidTestCase() {
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlOrderedListtWhiteSpace_isEqual() {
+    fun parseHtmlToSpanToHtmlListOrderedWhiteSpace_isEqual() {
         val input =
-                HTML_ORDERED_LIST_WITH_WHITE_SPACE
+                HTML_LIST_ORDERED_WITH_WHITE_SPACE
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
-        Assert.assertEquals(HTML_ORDERED_LIST, output)
+        Assert.assertEquals(HTML_LIST_ORDERED, output)
     }
 
     /**
@@ -270,8 +269,8 @@ class AztecParserTest : AndroidTestCase() {
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlOrderedListSurroundedByText_isEqual() {
-        val input = "1" + HTML_ORDERED_LIST + "2"
+    fun parseHtmlToSpanToHtmlListOrderedSurroundedByText_isEqual() {
+        val input = "1" + HTML_LIST_ORDERED + "2"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
@@ -287,23 +286,23 @@ class AztecParserTest : AndroidTestCase() {
     @Test
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlListOrderedSurroundedByNewlineAndText_isEqual() {
-        val input = "1<br>$HTML_ORDERED_LIST<br>2"
-        val parsed = "1$HTML_ORDERED_LIST<br>2"
+        val input = "1<br>$HTML_LIST_ORDERED<br>2"
+        val parsed = "1$HTML_LIST_ORDERED<br>2"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(parsed, output)
     }
 
     /**
-     * Parse ordered lists with text inbetween from HTML to span to HTML.  If input and output are equal with
+     * Parse ordered lists with text between from HTML to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlListsWithTextInbetween_isEqual() {
-        val input = HTML_ORDERED_LIST + "1" + HTML_ORDERED_LIST
+    fun parseHtmlToSpanToHtmlListsWithTextBetween_isEqual() {
+        val input = HTML_LIST_ORDERED + "1" + HTML_LIST_ORDERED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
@@ -348,25 +347,25 @@ class AztecParserTest : AndroidTestCase() {
         output = mParser.toHtml(span)
         Assert.assertEquals(parsed, output)
 
-        input = "<br>$HTML_NUMBERED_LIST"
+        input = "<br>$HTML_LIST_ORDERED"
         span = SpannableString(mParser.fromHtml(input, context))
         Assert.assertEquals("\nOrdered", span.toString())
         output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
 
-        input = "Text<br>$HTML_NUMBERED_LIST"
+        input = "Text<br>$HTML_LIST_ORDERED"
         parsed = input.replace("<br>", "")
         span = SpannableString(mParser.fromHtml(input, context))
         output = mParser.toHtml(span)
         Assert.assertEquals(parsed, output)
 
-        input = "<br>$HTML_BULLET"
+        input = "<br>$HTML_LIST_UNORDERED"
         span = SpannableString(mParser.fromHtml(input, context))
-        Assert.assertEquals("\nBullet", span.toString())
+        Assert.assertEquals("\nUnordered", span.toString())
         output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
 
-        input = "Text<br>$HTML_BULLET"
+        input = "Text<br>$HTML_LIST_UNORDERED"
         parsed = input.replace("<br>", "")
         span = SpannableString(mParser.fromHtml(input, context))
         output = mParser.toHtml(span)
@@ -505,16 +504,16 @@ class AztecParserTest : AndroidTestCase() {
     }
 
     /**
-     * Parse quote with bullets from HTML to span to HTML.  If input and output are equal with
+     * Parse quote with ordered list from HTML to span to HTML.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlQuoteWithBullets_isEqual() {
+    fun parseHtmlToSpanToHtmlQuoteWithListOrdered_isEqual() {
         val input =
-                HTML_QUOTE_WITH_BULLETS
+                HTML_QUOTE_WITH_LIST_ORDERED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
@@ -698,8 +697,8 @@ class AztecParserTest : AndroidTestCase() {
 
     @Test
     @Throws(Exception::class)
-    fun preserveBulletListWithEmptyListItem() {
-        val input = HTML_BULLET_LIST_WITH_EMPTY_ITEM
+    fun preserveListListUnorderedWithEmptyListItem() {
+        val input = HTML_LIST_UNORDERED_WITH_EMPTY_ITEM
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
@@ -707,8 +706,8 @@ class AztecParserTest : AndroidTestCase() {
 
     @Test
     @Throws(Exception::class)
-    fun preserveNumberedListWithEmptyListItem() {
-        val input = HTML_NUMBERED_LIST_WITH_EMPTY_ITEM
+    fun preserveListOrderedWithEmptyListItem() {
+        val input = HTML_LIST_ORDERED_WITH_EMPTY_ITEM
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
@@ -757,16 +756,16 @@ class AztecParserTest : AndroidTestCase() {
     }
 
     /**
-     * Parse bullet text from span to HTML to span.  If input and output are equal with
+     * Parse ordered list text from span to HTML to span.  If input and output are equal with
      * the same length and corresponding characters, [AztecParser] is correct.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun parseSpanToHtmlToSpanBullet_isEqual() {
+    fun parseSpanToHtmlToSpanOrdered_isEqual() {
         val input = SpannableString(
-                SPAN_BULLET
+                SPAN_LIST_ORDERED
         )
         val html = mParser.toHtml(input)
         val output = mParser.fromHtml(html, context)
@@ -998,7 +997,7 @@ class AztecParserTest : AndroidTestCase() {
     @Test
     @Throws(Exception::class)
     fun parseHtmlToSpanToHtmlHeaderSurroundedByList_isEqual() {
-        val input = HTML_ORDERED_LIST + HTML_SINGLE_HEADER + HTML_ORDERED_LIST
+        val input = HTML_LIST_ORDERED + HTML_SINGLE_HEADER + HTML_LIST_ORDERED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
@@ -1051,7 +1050,7 @@ class AztecParserTest : AndroidTestCase() {
 
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlOrderedListWithTrailingEmptyItem_isEqual() {
+    fun parseHtmlToSpanToHtmlListOrderedWithTrailingEmptyItem_isEqual() {
         val input = "<ol><li>Ordered item</li><li></li></ol>"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
@@ -1060,7 +1059,7 @@ class AztecParserTest : AndroidTestCase() {
 
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlUnorderedListWithLinebreak_isEqual() {
+    fun parseHtmlToSpanToHtmlListUnorderedWithLinebreak_isEqual() {
         val input = "<ul><li>a</li></ul><br>1"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
@@ -1069,7 +1068,7 @@ class AztecParserTest : AndroidTestCase() {
 
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlOrderedListWithTrailingEmptyItemAndLinebreak_isEqual() {
+    fun parseHtmlToSpanToHtmlListOrderedWithTrailingEmptyItemAndLinebreak_isEqual() {
         val input = "<ol><li>Ordered item</li><li></li></ol><br>1"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
@@ -1078,7 +1077,7 @@ class AztecParserTest : AndroidTestCase() {
 
     @Test
     @Throws(Exception::class)
-    fun parseHtmlToSpanToHtmlUnorderedListFollowedByLinebreak_isEqual() {
+    fun parseHtmlToSpanToHtmlListUnorderedFollowedByLinebreak_isEqual() {
         val input = "<ol><li>Ordered item</li><li>b</li></ol><br>1"
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -37,6 +37,7 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_PAGE = "<!--nextpage-->"
     private val HTML_QUOTE = "<blockquote>Quote</blockquote>"
     private val HTML_QUOTE_WITH_LIST_ORDERED = "<blockquote><ol><li>Ordered</li></ol></blockquote>"
+    private val HTML_QUOTE_WITH_LIST_UNORDERED = "<blockquote><ul><li>Unordered</li></ul></blockquote>"
     private val HTML_QUOTE_WITH_WHITE_SPACE = "<blockquote>Quote<br><br></br></blockquote>"
     private val HTML_STRIKETHROUGH = "<s>Strikethrough</s>" // <s> or <strike> or <del>
     private val HTML_UNDERLINE = "<u>Underline</u><br><br>"
@@ -114,6 +115,8 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_QUOTE +
                 HTML_LINK +
                 HTML_UNKNOWN +
+                HTML_QUOTE_WITH_LIST_ORDERED +
+                HTML_QUOTE_WITH_LIST_UNORDERED +
                 HTML_COMMENT +
                 HTML_NESTED_MIXED +
                 HTML_NESTED_EMPTY_END +
@@ -137,6 +140,8 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_QUOTE +
                 HTML_LINK +
                 HTML_UNKNOWN_PARSED +
+                HTML_QUOTE_WITH_LIST_ORDERED +
+                HTML_QUOTE_WITH_LIST_UNORDERED +
                 HTML_COMMENT +
                 HTML_NESTED_MIXED +
                 HTML_NESTED_EMPTY_END +
@@ -515,6 +520,22 @@ class AztecParserTest : AndroidTestCase() {
     fun parseHtmlToSpanToHtmlQuoteWithListOrdered_isEqual() {
         val input =
                 HTML_QUOTE_WITH_LIST_ORDERED
+        val span = SpannableString(mParser.fromHtml(input, context))
+        val output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+    }
+
+    /**
+     * Parse quote with unordered list from HTML to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlQuoteWithListUnordered_isEqual() {
+        val input =
+                HTML_QUOTE_WITH_LIST_UNORDERED
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -786,7 +786,7 @@ class AztecParserTest : AndroidTestCase() {
      */
     @Test
     @Throws(Exception::class)
-    fun parseSpanToHtmlToSpanOrdered_isEqual() {
+    fun parseSpanToHtmlToSpanListOrdered_isEqual() {
         val input = SpannableString(
                 SPAN_LIST_ORDERED
         )
@@ -803,7 +803,7 @@ class AztecParserTest : AndroidTestCase() {
      */
     @Test
     @Throws(Exception::class)
-    fun parseSpanToHtmlToSpanUnordered_isEqual() {
+    fun parseSpanToHtmlToSpanListUnordered_isEqual() {
         val input = SpannableString(
                 SPAN_LIST_UNORDERED
         )

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -22,6 +22,7 @@ class AztecParserTest : AndroidTestCase() {
     private val HTML_BULLET = "<ul><li>Bullet</li></ul>"
     private val HTML_BULLET_WITH_WHITE_SPACE = "<ul><li>Bullet<br></br></li></ul>"
     private val HTML_BULLET_LIST_WITH_EMPTY_ITEM = "<ul><li>item</li><li></li><li>item 2</li></ul>"
+    private val HTML_NUMBERED_LIST = "<ol><li>Ordered</li></ol>"
     private val HTML_NUMBERED_LIST_WITH_EMPTY_ITEM = "<ol><li>item</li><li></li><li>item 2</li></ol>"
     private val HTML_BULLET_WITH_QUOTE = "<ul><li><blockquote>Quote</blockquote></li></ul>"
     private val HTML_ORDERED_LIST = "<ol><li>Ordered item</li></ol>"
@@ -306,6 +307,70 @@ class AztecParserTest : AndroidTestCase() {
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)
         Assert.assertEquals(input, output)
+    }
+
+    /**
+     * Parse block elements with preceding newline from HTML to span to HTML.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.  When block elements
+     * replace preceding <br> with [BlockElementLinebreak], input will not equal output.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseHtmlToSpanToHtmlLinebreakFollowedByBlock_isEqual() {
+        var input: String
+        var output: String
+        var parsed: String
+        var span: SpannableString
+
+        input = "<br>$HTML_SINGLE_HEADER"
+        span = SpannableString(mParser.fromHtml(input, context))
+        Assert.assertEquals("\nHeading 1", span.toString())
+        output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+
+        input = "Text<br>$HTML_SINGLE_HEADER"
+        parsed = input.replace("<br>", "")
+        span = SpannableString(mParser.fromHtml(input, context))
+        output = mParser.toHtml(span)
+        Assert.assertEquals(parsed, output)
+
+        input = "<br>$HTML_QUOTE"
+        span = SpannableString(mParser.fromHtml(input, context))
+        Assert.assertEquals("\nQuote", span.toString())
+        output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+
+        input = "Text<br>$HTML_QUOTE"
+        parsed = input.replace("<br>", "")
+        span = SpannableString(mParser.fromHtml(input, context))
+        output = mParser.toHtml(span)
+        Assert.assertEquals(parsed, output)
+
+        input = "<br>$HTML_NUMBERED_LIST"
+        span = SpannableString(mParser.fromHtml(input, context))
+        Assert.assertEquals("\nOrdered", span.toString())
+        output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+
+        input = "Text<br>$HTML_NUMBERED_LIST"
+        parsed = input.replace("<br>", "")
+        span = SpannableString(mParser.fromHtml(input, context))
+        output = mParser.toHtml(span)
+        Assert.assertEquals(parsed, output)
+
+        input = "<br>$HTML_BULLET"
+        span = SpannableString(mParser.fromHtml(input, context))
+        Assert.assertEquals("\nBullet", span.toString())
+        output = mParser.toHtml(span)
+        Assert.assertEquals(input, output)
+
+        input = "Text<br>$HTML_BULLET"
+        parsed = input.replace("<br>", "")
+        span = SpannableString(mParser.fromHtml(input, context))
+        output = mParser.toHtml(span)
+        Assert.assertEquals(parsed, output)
     }
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -108,10 +108,10 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_STRIKETHROUGH +
                 HTML_LIST_ORDERED +
                 HTML_LIST_ORDERED_WITH_EMPTY_ITEM +
-//                HTML_LIST_ORDERED_WITH_QUOTE +
+// TODO:                HTML_LIST_ORDERED_WITH_QUOTE +
                 HTML_LIST_UNORDERED +
                 HTML_LIST_UNORDERED_WITH_EMPTY_ITEM +
-//                HTML_LIST_UNORDERED_WITH_QUOTE +
+// TODO:                HTML_LIST_UNORDERED_WITH_QUOTE +
                 HTML_QUOTE +
                 HTML_LINK +
                 HTML_UNKNOWN +
@@ -133,10 +133,10 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_STRIKETHROUGH +
                 HTML_LIST_ORDERED +
                 HTML_LIST_ORDERED_WITH_EMPTY_ITEM +
-//                HTML_LIST_ORDERED_WITH_QUOTE +
+// TODO:                HTML_LIST_ORDERED_WITH_QUOTE +
                 HTML_LIST_UNORDERED +
                 HTML_LIST_UNORDERED_WITH_EMPTY_ITEM +
-//                HTML_LIST_UNORDERED_WITH_QUOTE +
+// TODO:                HTML_LIST_UNORDERED_WITH_QUOTE +
                 HTML_QUOTE +
                 HTML_LINK +
                 HTML_UNKNOWN_PARSED +

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -69,6 +69,7 @@ class AztecParserTest : AndroidTestCase() {
 
     private val SPAN_BOLD = "Bold\n\n"
     private val SPAN_LIST_ORDERED = "Ordered\n\n"
+    private val SPAN_LIST_UNORDERED = "Unordered\n\n"
     private val SPAN_COMMENT = "Comment\n\n"
     private val SPAN_HEADING = "Heading 1\n\nHeading 2\n\nHeading 3\n\nHeading 4\n\nHeading 5\n\nHeading 6\n\n"
     private val SPAN_ITALIC = "Italic\n\n"
@@ -728,6 +729,7 @@ class AztecParserTest : AndroidTestCase() {
                 SPAN_ITALIC +
                 SPAN_UNDERLINE +
                 SPAN_STRIKETHROUGH +
+                SPAN_LIST_UNORDERED +
                 SPAN_QUOTE +
                 SPAN_LINK +
                 SPAN_UNKNOWN +
@@ -766,6 +768,23 @@ class AztecParserTest : AndroidTestCase() {
     fun parseSpanToHtmlToSpanOrdered_isEqual() {
         val input = SpannableString(
                 SPAN_LIST_ORDERED
+        )
+        val html = mParser.toHtml(input)
+        val output = mParser.fromHtml(html, context)
+        Assert.assertEquals(input, output)
+    }
+
+    /**
+     * Parse unordered list text from span to HTML to span.  If input and output are equal with
+     * the same length and corresponding characters, [AztecParser] is correct.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun parseSpanToHtmlToSpanUnordered_isEqual() {
+        val input = SpannableString(
+                SPAN_LIST_UNORDERED
         )
         val html = mParser.toHtml(input)
         val output = mParser.fromHtml(html, context)


### PR DESCRIPTION
### Fix
Remove extra newline preceding block elements as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/146.

### Test
1. Tap ***HTML*** format button.
2. Enter HTML shown in screenshots in this [comment](https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/146#issuecomment-267489480).
3. Tap ***HTML*** format button.