### PR TITLE
Add Fill Viewport Attribute to AztecText and SourceViewAztecText

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,7 +16,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/formatting_toolbar"
-        android:layout_alignParentTop="true">
+        android:layout_alignParentTop="true"
+        android:fillViewport="true">
 
         <FrameLayout
             android:layout_width="match_parent"
@@ -25,7 +26,8 @@
             <org.wordpress.aztec.AztecText
                 android:id="@+id/aztec"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
+                android:gravity="top|start"
                 android:hint="@string/edit_hint"
                 android:paddingEnd="16dp"
                 android:paddingLeft="16dp"
@@ -39,7 +41,7 @@
             <org.wordpress.aztec.source.SourceViewEditText
                 android:id="@+id/source"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:gravity="top|start"
                 android:hint="@string/source_hint"
                 android:inputType="textNoSuggestions|textMultiLine"


### PR DESCRIPTION
### Fix
Tapping anywhere in the visual and HTML view text area shows the keyboard and allows entering text as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/179.  See the layout bounds in the screenshots below.

![viewport](https://cloud.githubusercontent.com/assets/3827611/21914512/176a9a18-d8f1-11e6-86bc-95b1a2c653bd.png)

### Test
1. Enter text filling up less than the full screen.
2. Dismiss the keyboard.
3. Tap outside the entered text area.