### PR TITLE
Issue/181 update placeholder images

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -23,7 +23,6 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.aztec.AztecText
-import org.wordpress.aztec.glideloader.GlideImageLoader
 import org.wordpress.aztec.picassoloader.PicassoImageLoader
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
@@ -65,7 +64,7 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
                 "</div>" +
                 "<br>"
         private val CODE = "<code>if (value == 5) printf(value)</code><br>"
-        private val IMG = "<img src=\"http://4k.com/wp-content/uploads/2014/06/4k-image-santiago.jpg\" />"
+        private val IMG = "<img src=\"https://cloud.githubusercontent.com/assets/3827611/21950131/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />"
         private val EXAMPLE =
                 IMG +
                 HEADING +

--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -752,7 +752,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         final int start = text.length();
 
         // TODO: we should some placeholder drawable while loading imges
-        Drawable loadingDrawable = ContextCompat.getDrawable(context, android.R.drawable.progress_indeterminate_horizontal);
+        Drawable loadingDrawable = ContextCompat.getDrawable(context, R.drawable.ic_image_loading);
 
         loadingDrawable.setBounds(0, 0, loadingDrawable.getIntrinsicWidth(), loadingDrawable.getIntrinsicHeight());
         final ImageSpan imageSpan = new ImageSpan(loadingDrawable, src);

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -503,7 +503,7 @@ class AztecText : EditText, TextWatcher {
                     }
 
                     override fun onImageLoadingFailed() {
-                        val drawable = ContextCompat.getDrawable(context, android.R.drawable.ic_menu_report_image)
+                        val drawable = ContextCompat.getDrawable(context, R.drawable.ic_image_failed)
                         replaceImage(drawable)
                     }
 

--- a/aztec/src/main/res/drawable/ic_image_failed.xml
+++ b/aztec/src/main/res/drawable/ic_image_failed.xml
@@ -1,0 +1,23 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="96dp"
+    android:width="96dp"
+    android:viewportHeight="96.0"
+    android:viewportWidth="96.0" >
+
+    <path
+        android:fillColor="#66888888"
+        android:pathData="M0,0h96v96H0V0" >
+    </path>
+
+    <path
+        android:fillColor="#66aaaaaa"
+        android:pathData="M57.6,36.8h7.5v7.5h-7.5V36.8z M31.1,36.8h7.5v7.5h-7.5V36.8z M57.6,48h15v7.5h-15V48z M23.6,48h15v7.5h-15V48z M57.4,59.2h22.5v7.5H57.4V59.2z M16.1,59.2h22.5v7.5H16.1V59.2z" >
+    </path>
+
+    <path
+        android:fillColor="#66aaaaaa"
+        android:pathData="M42.4,23.2h11.2v32.2H42.4V23.2z M53.6,68.6H42.4v-9.4h11.2V68.6z" >
+    </path>
+
+</vector>

--- a/aztec/src/main/res/drawable/ic_image_loading.xml
+++ b/aztec/src/main/res/drawable/ic_image_loading.xml
@@ -1,0 +1,23 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="96dp"
+    android:width="96dp"
+    android:viewportHeight="96.0"
+    android:viewportWidth="96.0" >
+
+    <path
+        android:fillColor="#66888888"
+        android:pathData="M0,0h96v96H0V0z" >
+    </path>
+
+    <path
+        android:fillColor="#66aaaaaa"
+        android:pathData="M57.6,36.8h7.5v7.5h-7.5V36.8z M31.1,36.8h7.5v7.5h-7.5V36.8z M57.6,48h15v7.5h-15V48z M23.6,48h15v7.5h-15V48z M57.4,59.2h22.5v7.5H57.4V59.2z M16.1,59.2h22.5v7.5H16.1V59.2z" >
+    </path>
+
+    <path
+        android:fillColor="#66aaaaaa"
+        android:pathData="M48,72.7l5.6-5.9H42.4L48,72.7z M42.4,36.8h11.2v30H42.4V36.8z M53.6,32.6H42.4V27c0-3.8,3.8-3.8,3.8-3.8h3.7 c0,0,3.8,0,3.8,3.8V32.6z" >
+    </path>
+
+</vector>

--- a/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
+++ b/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
@@ -32,12 +32,12 @@ class PicassoImageLoader(private val context: Context, aztec: AztecText) : Html.
                 targets.remove(source)
             }
 
-            override fun onBitmapFailed(errorDrawable: Drawable?) {
+            override fun onBitmapFailed(errorDrawable: Drawable) {
                 callbacks.onImageLoadingFailed()
                 targets.remove(source)
             }
 
-            override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
+            override fun onPrepareLoad(placeHolderDrawable: Drawable) {}
         }
 
         // add a strong reference to the target until it's called or the view gets destroyed

--- a/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
+++ b/picasso-loader/src/main/java/org/wordpress/aztec/picassoloader/PicassoImageLoader.kt
@@ -32,12 +32,12 @@ class PicassoImageLoader(private val context: Context, aztec: AztecText) : Html.
                 targets.remove(source)
             }
 
-            override fun onBitmapFailed(errorDrawable: Drawable) {
+            override fun onBitmapFailed(errorDrawable: Drawable?) {
                 callbacks.onImageLoadingFailed()
                 targets.remove(source)
             }
 
-            override fun onPrepareLoad(placeHolderDrawable: Drawable) {}
+            override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
         }
 
         // add a strong reference to the target until it's called or the view gets destroyed


### PR DESCRIPTION
### Fix
Update placeholder images as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/181.

### Test
1. Open demo app.
2. Notice new example image.
3. Tap ***HTML*** format toolbar button.
4. Delete a character from the `src` attribute in the `img` element.
5. Tap ***HTML*** format toolbar button.
6. Notice loading image placeholder.
7. Notice failed image placeholder.