### PR TITLE
Add Focus State to Format Toolbar Buttons

### DIFF
--- a/aztec/src/main/res/drawable/format_bar_button_bold_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_bold_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_bold_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_bold_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_bold_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_bold"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_bold_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_bold_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_bold_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_bold_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_bold" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_header_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_header_selector.xml
@@ -2,7 +2,10 @@
 
 <selector
     xmlns:android="http://schemas.android.com/apk/res/android" >
+
     <item android:drawable="@drawable/format_bar_button_header_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_header_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_header_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_header" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_html_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_html_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_html_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_html_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_html_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_html"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_html_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_html_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_html_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_html_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_html" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_italic_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_italic_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_italic_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_italic_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_italic_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_italic"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_italic_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_italic_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_italic_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_italic_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_italic" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_link_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_link_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_link_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_link_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_link_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_link"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_link_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_link_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_link_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_link_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_link" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
@@ -2,7 +2,10 @@
 
 <selector
     xmlns:android="http://schemas.android.com/apk/res/android" >
+
     <item android:drawable="@drawable/format_bar_button_media_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_pressed="true" />
-    <item android:drawable="@drawable/format_bar_button_media"/>
+    <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_media" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_more_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_more_selector.xml
@@ -5,6 +5,7 @@
 
     <item android:drawable="@drawable/format_bar_button_more_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_more_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_more_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_more" />
 
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_ol_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ol_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_ol_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_ol_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_ol_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_ol"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_ol_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_ol" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_page_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_page_selector.xml
@@ -5,6 +5,7 @@
 
     <item android:drawable="@drawable/format_bar_button_page_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_page_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_page_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_page" />
 
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_quote_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_quote_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_quote_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_quote_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_quote_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_quote"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_quote_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_quote_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_quote_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_quote_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_quote" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_strikethrough_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_strikethrough_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_strikethrough_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_strikethrough"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_strikethrough_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_strikethrough_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_strikethrough_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_strikethrough_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_strikethrough" />
+
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_ul_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_ul_selector.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_ul_disabled"/>
-    <item android:state_checked="true" android:drawable="@drawable/format_bar_button_ul_highlighted"/>
-    <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_ul_highlighted"/>
-    <item android:drawable="@drawable/format_bar_button_ul"/>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_ul_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_checked="true" />
+    <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_pressed="true" />
+    <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_ul" />
+
 </selector>


### PR DESCRIPTION
### Fix
Add focus state to format toolbar buttons as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/183.

### Test
1. Run app with hardware keyboard.
2. Tap ***Tab*** key.
3. Notice format toolbar button is not shown as focused.