### PR TITLE
Adjust heading sizes to match the WP visual editor

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -11,12 +11,12 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
     override var attributes: String = attrs
 
     companion object {
-        private val SCALE_H1: Float = 2.0f
-        private val SCALE_H2: Float = 1.8f
-        private val SCALE_H3: Float = 1.6f
-        private val SCALE_H4: Float = 1.4f
-        private val SCALE_H5: Float = 1.2f
-        private val SCALE_H6: Float = 1.0f
+        private val SCALE_H1: Float = 1.73f
+        private val SCALE_H2: Float = 1.32f
+        private val SCALE_H3: Float = 1.02f
+        private val SCALE_H4: Float = 0.87f
+        private val SCALE_H5: Float = 0.72f
+        private val SCALE_H6: Float = 0.60f
 
         fun getTextFormat(tag: String): TextFormat {
             when (tag.toLowerCase()) {


### PR DESCRIPTION
### Fix
#163 

### Test

Here's a screenshot of the visual editor on a Nexus 5X:
![hybrid-editor-headings](https://cloud.githubusercontent.com/assets/1032913/22085135/9fbbf138-dd87-11e6-88d5-ceaf31367981.jpg)

And here's Aztec's screenshot with the PR fix:
![aztec-editor-headings-fixed](https://cloud.githubusercontent.com/assets/1032913/22085149/ad67ddd8-dd87-11e6-818d-6cbf8c081f12.jpg)
