### PR TITLE
Add Margin to Image Spans

### DIFF
--- a/aztec/build.gradle
+++ b/aztec/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
     compile 'org.jsoup:jsoup:1.9.2'
+    compile "org.wordpress:utils:1.14.0"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.4'

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -36,6 +36,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.inputmethod.BaseInputConnection
 import android.widget.EditText
+import org.wordpress.android.util.DisplayUtils
 import org.wordpress.aztec.formatting.BlockFormatter
 import org.wordpress.aztec.formatting.InlineFormatter
 import org.wordpress.aztec.formatting.LineBlockFormatter
@@ -558,7 +559,15 @@ class AztecText : EditText, TextWatcher {
                     }
                 }
 
-                imageGetter?.loadImage(it.source, callbacks, context.resources.displayMetrics.widthPixels)
+                /*
+                 * Following Android guidelines for keylines and spacing, screen edge margins should
+                 * be 16dp.  Therefore, the width of images should be the width of the screen minus
+                 * 16dp on both sides (i.e. 16 * 2 = 32).
+                 *
+                 * (https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids)
+                 */
+                val width = context.resources.displayMetrics.widthPixels - DisplayUtils.dpToPx(context, 32)
+                imageGetter?.loadImage(it.source, callbacks, width)
             }
         }
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -564,7 +564,7 @@ class AztecText : EditText, TextWatcher {
                  * be 16dp.  Therefore, the width of images should be the width of the screen minus
                  * 16dp on both sides (i.e. 16 * 2 = 32).
                  *
-                 * (https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids)
+                 * https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids
                  */
                 val width = context.resources.displayMetrics.widthPixels - DisplayUtils.dpToPx(context, 32)
                 imageGetter?.loadImage(it.source, callbacks, width)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCommentSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCommentSpan.kt
@@ -6,6 +6,8 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.text.style.ImageSpan
 
+import org.wordpress.android.util.DisplayUtils
+
 class AztecCommentSpan(val context: Context, drawable: Drawable) : ImageSpan(drawable) {
     companion object {
         private val rect: Rect = Rect()
@@ -39,7 +41,14 @@ class AztecCommentSpan(val context: Context, drawable: Drawable) : ImageSpan(dra
             return rect
         }
 
-        val width = context.resources.displayMetrics.widthPixels
+        /*
+         * Following Android guidelines for keylines and spacing, screen edge margins should
+         * be 16dp.  Therefore, the width of images should be the width of the screen minus
+         * 16dp on both sides (i.e. 16 * 2 = 32).
+         *
+         * (https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids)
+         */
+        val width = context.resources.displayMetrics.widthPixels - DisplayUtils.dpToPx(context, 32)
         val height = drawable.intrinsicHeight * width / drawable.intrinsicWidth
         drawable.setBounds(0, 0, width, height)
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCommentSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCommentSpan.kt
@@ -46,7 +46,7 @@ class AztecCommentSpan(val context: Context, drawable: Drawable) : ImageSpan(dra
          * be 16dp.  Therefore, the width of images should be the width of the screen minus
          * 16dp on both sides (i.e. 16 * 2 = 32).
          *
-         * (https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids)
+         * https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids
          */
         val width = context.resources.displayMetrics.widthPixels - DisplayUtils.dpToPx(context, 32)
         val height = drawable.intrinsicHeight * width / drawable.intrinsicWidth

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -44,7 +44,7 @@ class AztecMediaSpan(val context: Context, drawable: Drawable, source: String) :
          * be 16dp.  Therefore, the width of images should be the width of the screen minus
          * 16dp on both sides (i.e. 16 * 2 = 32).
          *
-         * (https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids)
+         * https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids
          */
         val width = context.resources.displayMetrics.widthPixels - DisplayUtils.dpToPx(context, 32)
         val height = drawable.intrinsicHeight * width / drawable.intrinsicWidth

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -9,6 +9,8 @@ import android.text.style.ParagraphStyle
 import android.view.View
 import android.widget.Toast
 
+import org.wordpress.android.util.DisplayUtils
+
 class AztecMediaSpan(val context: Context, drawable: Drawable, source: String) : ImageSpan(drawable), ParagraphStyle {
     private val html = source
 
@@ -37,7 +39,14 @@ class AztecMediaSpan(val context: Context, drawable: Drawable, source: String) :
             return rect
         }
 
-        val width = context.resources.displayMetrics.widthPixels
+        /*
+         * Following Android guidelines for keylines and spacing, screen edge margins should
+         * be 16dp.  Therefore, the width of images should be the width of the screen minus
+         * 16dp on both sides (i.e. 16 * 2 = 32).
+         *
+         * (https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids)
+         */
+        val width = context.resources.displayMetrics.widthPixels - DisplayUtils.dpToPx(context, 32)
         val height = drawable.intrinsicHeight * width / drawable.intrinsicWidth
         drawable.setBounds(0, 0, width, height)
 


### PR DESCRIPTION
### Fix
Add margin according to [Android guidelines for keylines and spacing](https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-baseline-grids) using [DisplayUtils.dpToPx](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java#L47) method as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/83.

### Test
1. Open demonstration app.
2. Notice Aztec example image is not cropped.
3. Notice ***More*** image is not cropped.
4. Notice ***Page*** image is not cropped.
5. Tap ***Media*** format button.
6. Tap ***Photo*** option.
7. Tap ***Device camera*** option.
8. Take a picture.
9. Notice inserted picture in not cropped.