### PR TITLE
Issue/19 add media support

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -19,6 +19,7 @@ import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.widget.Toast
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ToastUtils
@@ -199,6 +200,10 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
         }
     }
 
+    override fun onPhotoLibraryMediaOptionSelected() {
+        Toast.makeText(this, "Open library", Toast.LENGTH_SHORT).show()
+    }
+
     override fun onPhotosMediaOptionSelected() {
         if (PermissionUtils.checkAndRequestStoragePermission(this, MEDIA_PHOTOS_PERMISSION_REQUEST_CODE)) {
             val intent: Intent
@@ -219,6 +224,10 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
                 ToastUtils.showToast(this, getString(R.string.error_chooser_photo), ToastUtils.Duration.LONG)
             }
         }
+    }
+
+    override fun onVideoLibraryMediaOptionSelected() {
+        Toast.makeText(this, "Open library", Toast.LENGTH_SHORT).show()
     }
 
     override fun onVideosMediaOptionSelected() {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -200,6 +200,10 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
         }
     }
 
+    override fun onGalleryMediaOptionSelected() {
+        Toast.makeText(this, "Launch gallery", Toast.LENGTH_SHORT).show()
+    }
+
     override fun onPhotoLibraryMediaOptionSelected() {
         Toast.makeText(this, "Open library", Toast.LENGTH_SHORT).show()
     }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -44,6 +44,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
     interface OnMediaOptionSelectedListener {
         fun onCameraPhotoMediaOptionSelected()
         fun onCameraVideoMediaOptionSelected()
+        fun onGalleryMediaOptionSelected()
         fun onPhotoLibraryMediaOptionSelected()
         fun onPhotosMediaOptionSelected()
         fun onVideoLibraryMediaOptionSelected()
@@ -97,7 +98,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         when (item?.itemId) {
             // Media popup menu options
             R.id.gallery -> {
-                Toast.makeText(context, "Launch gallery", Toast.LENGTH_SHORT).show()
+                mediaOptionSelectedListener?.onGalleryMediaOptionSelected()
                 return true
             }
             R.id.photo -> {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -44,7 +44,9 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
     interface OnMediaOptionSelectedListener {
         fun onCameraPhotoMediaOptionSelected()
         fun onCameraVideoMediaOptionSelected()
+        fun onPhotoLibraryMediaOptionSelected()
         fun onPhotosMediaOptionSelected()
+        fun onVideoLibraryMediaOptionSelected()
         fun onVideosMediaOptionSelected()
     }
 
@@ -348,7 +350,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
 
         val library = dialog.findViewById(R.id.media_library)
         library.setOnClickListener({
-            Toast.makeText(context, "Open library", Toast.LENGTH_SHORT).show()
+            mediaOptionSelectedListener?.onPhotoLibraryMediaOptionSelected()
             addPhotoMediaDialog?.dismiss()
         })
 
@@ -377,7 +379,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
 
         val library = dialog.findViewById(R.id.media_library)
         library.setOnClickListener({
-            Toast.makeText(context, "Open library", Toast.LENGTH_SHORT).show()
+            mediaOptionSelectedListener?.onVideoLibraryMediaOptionSelected()
             addVideoMediaDialog?.dismiss()
         })
 


### PR DESCRIPTION
### Fix
Add gallery, photo library, and video library functions to the media options selected interface.

### Test
1. Tap ***Media*** format button.
2. Tap ***Gallery*** option.
3. Notice "Launch gallery" message.
5. Tap ***Media*** format button.
6. Tap ***Photos*** option.
7. Tap ***Media library*** option.
8. Notice "Open library" message. 