### PR TITLE
Code block as MetricAffectingSpan

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -57,7 +57,7 @@ class AztecCodeSpan : MetricAffectingSpan, ParcelableSpan, AztecContentSpan, Azt
     }
 
     override fun describeContents(): Int {
-        return 0;
+        return 0
     }
 
     override fun writeToParcel(dest: Parcel, flags: Int) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -22,11 +22,10 @@ import android.os.Parcel
 import android.text.ParcelableSpan
 import android.text.TextPaint
 import android.text.TextUtils
-import android.text.style.CharacterStyle
-import android.text.style.UpdateAppearance
+import android.text.style.MetricAffectingSpan
 import org.wordpress.aztec.formatting.InlineFormatter
 
-class AztecCodeSpan : CharacterStyle, UpdateAppearance, ParcelableSpan, AztecContentSpan, AztecInlineSpan {
+class AztecCodeSpan : MetricAffectingSpan, ParcelableSpan, AztecContentSpan, AztecInlineSpan {
 
     private val TAG: String = "code"
 
@@ -78,6 +77,14 @@ class AztecCodeSpan : CharacterStyle, UpdateAppearance, ParcelableSpan, AztecCon
     }
 
     override fun updateDrawState(tp: TextPaint?) {
+        configureTextPaint(tp)
+    }
+
+    override fun updateMeasureState(tp: TextPaint?) {
+        configureTextPaint(tp)
+    }
+
+    private fun configureTextPaint(tp: TextPaint?) {
         tp?.typeface = Typeface.MONOSPACE
         tp?.bgColor = codeBackground
         tp?.color = codeColor


### PR DESCRIPTION
### Fix #197

Code block needs to subclass `MetricAffectingSpan` in order for the system to properly account for the change in metrics (due to typeface change).

### Test
1. While in html mode, erase all text in the demo app and put in `<code>value = hello, world! if (value != null) print(value)</code><br>`
2. Switch to visual mode
3. Code block should be displayed fine without any part of it clipped by the device's screen edges

### Review
@theck13 , wanna pick this up? Thanks!