### PR TITLE
No extracted UI mode, hide actionbar in landscape

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.BitmapDrawable
@@ -18,6 +19,7 @@ import android.support.v4.content.FileProvider
 import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
+import android.view.MotionEvent
 import android.view.View
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PermissionUtils
@@ -29,7 +31,8 @@ import org.wordpress.aztec.toolbar.AztecToolbar
 import org.wordpress.aztec.toolbar.AztecToolbar.OnMediaOptionSelectedListener
 import java.io.File
 
-class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnRequestPermissionsResultCallback {
+class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnRequestPermissionsResultCallback,
+        View.OnTouchListener, AztecText.OnImeBackListener {
     companion object {
         private val HEADING =
                 "<h1>Heading 1</h1>" +
@@ -99,6 +102,9 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
     private lateinit var source: SourceViewEditText
     private lateinit var formattingToolbar: AztecToolbar
 
+    private var mIsKeyboardOpen = false
+    private var mHideActionBarOnSoftKeyboardUp = false
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (resultCode == Activity.RESULT_OK) {
             var bitmap: Bitmap? = null
@@ -129,6 +135,12 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        // Setup hiding the action bar when the soft keyboard is displayed for narrow viewports
+        if (resources.configuration.orientation === Configuration.ORIENTATION_LANDSCAPE
+                && !resources.getBoolean(R.bool.is_large_tablet_landscape)) {
+            mHideActionBarOnSoftKeyboardUp = true
+        }
+
         aztec = findViewById(R.id.aztec) as AztecText
 
         aztec.imageGetter = PicassoImageLoader(this, aztec)
@@ -145,6 +157,96 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
         aztec.fromHtml(source.getPureHtml())
 
         source.history = aztec.history
+
+        aztec.setOnImeBackListener(this)
+        aztec.setOnTouchListener(this)
+        source.setOnImeBackListener(this)
+        source.setOnTouchListener(this)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mIsKeyboardOpen = false
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        showActionBarIfNeeded()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+
+        // Toggle action bar auto-hiding for the new orientation
+        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE
+                && !resources.getBoolean(R.bool.is_large_tablet_landscape)) {
+            mHideActionBarOnSoftKeyboardUp = true
+            hideActionBarIfNeeded()
+        } else {
+            mHideActionBarOnSoftKeyboardUp = false
+            showActionBarIfNeeded()
+        }
+    }
+
+    /**
+     * Returns true if a hardware keyboard is detected, otherwise false.
+     */
+    private fun isHardwareKeyboardPresent(): Boolean {
+        val config = resources.configuration
+        var returnValue = false
+        if (config.keyboard != Configuration.KEYBOARD_NOKEYS) {
+            returnValue = true
+        }
+        return returnValue
+    }
+
+    private fun hideActionBarIfNeeded() {
+
+        val actionBar = supportActionBar
+        if (actionBar != null
+                && !isHardwareKeyboardPresent()
+                && mHideActionBarOnSoftKeyboardUp
+                && mIsKeyboardOpen
+                && actionBar.isShowing) {
+            actionBar!!.hide()
+        }
+    }
+
+    /**
+     * Show the action bar if needed.
+     */
+    private fun showActionBarIfNeeded() {
+
+        val actionBar = supportActionBar
+        if (actionBar != null && !actionBar.isShowing) {
+            actionBar.show()
+        }
+    }
+
+    override fun onTouch(view: View, event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_UP) {
+            // If the WebView or EditText has received a touch event, the keyboard will be displayed and the action bar
+            // should hide
+            mIsKeyboardOpen = true
+            hideActionBarIfNeeded()
+        }
+        return false
+    }
+
+    override fun onBackPressed() {
+        mIsKeyboardOpen = false
+        showActionBarIfNeeded()
+
+        return super.onBackPressed()
+    }
+
+    /**
+     * Intercept back button press while soft keyboard is visible.
+     */
+    override fun onImeBack() {
+        mIsKeyboardOpen = false
+        showActionBarIfNeeded()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,6 +35,7 @@
                 android:paddingStart="16dp"
                 android:paddingTop="16dp"
                 android:scrollbars="vertical"
+                android:imeOptions="flagNoExtractUi"
                 aztec:historyEnable="true"
                 aztec:historySize="10"/>
 
@@ -53,6 +54,7 @@
                 android:scrollbars="vertical"
                 android:textSize="14sp"
                 android:visibility="gone"
+                android:imeOptions="flagNoExtractUi"
                 aztec:codeBackgroundColor="@android:color/transparent"
                 aztec:codeTextColor="@android:color/white"/>
 

--- a/app/src/main/res/values-w1280dp/dimens.xml
+++ b/app/src/main/res/values-w1280dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="is_large_tablet_landscape">true</bool>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,4 +11,6 @@
     <dimen name="spacing_extra">4dp</dimen>
     <item type="dimen" format="string" name="spacing_multiplier">1.0</item>
 
+    <bool name="is_large_tablet_landscape">false</bool>
+
 </resources>

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -32,6 +32,7 @@ import android.text.style.LeadingMarginSpan
 import android.text.style.ParagraphStyle
 import android.text.style.SuggestionSpan
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.inputmethod.BaseInputConnection
@@ -56,6 +57,8 @@ class AztecText : EditText, TextWatcher {
 
     private var onSelectionChangedListener: OnSelectionChangedListener? = null
 
+    private var onImeBackListener: OnImeBackListener? = null
+
     private var isViewInitialized = false
     private var previousCursorPosition = 0
 
@@ -76,6 +79,10 @@ class AztecText : EditText, TextWatcher {
 
     interface OnSelectionChangedListener {
         fun onSelectionChanged(selStart: Int, selEnd: Int)
+    }
+
+    interface OnImeBackListener {
+        fun onImeBack()
     }
 
     init {
@@ -265,6 +272,17 @@ class AztecText : EditText, TextWatcher {
 
     fun setOnSelectionChangedListener(onSelectionChangedListener: OnSelectionChangedListener) {
         this.onSelectionChangedListener = onSelectionChangedListener
+    }
+
+    fun setOnImeBackListener(listener: OnImeBackListener) {
+        this.onImeBackListener = listener
+    }
+
+    override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
+            onImeBackListener?.onImeBack()
+        }
+        return super.onKeyPreIme(keyCode, event)
     }
 
     public override fun onSelectionChanged(selStart: Int, selEnd: Int) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -10,8 +10,10 @@ import android.text.Editable
 import android.text.SpannableStringBuilder
 import android.text.TextWatcher
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.View
 import android.widget.EditText
+import org.wordpress.aztec.AztecText
 import org.wordpress.aztec.History
 import org.wordpress.aztec.R
 import org.wordpress.aztec.spans.AztecCursorSpan
@@ -25,6 +27,8 @@ class SourceViewEditText : EditText, TextWatcher {
         internal set
 
     private var styleTextWatcher: HtmlStyleTextWatcher? = null
+
+    private var onImeBackListener: AztecText.OnImeBackListener? = null
 
     lateinit var history: History
 
@@ -234,5 +238,16 @@ class SourceViewEditText : EditText, TextWatcher {
 
     fun isTextChangedListenerDisabled(): Boolean {
         return consumeEditEvent
+    }
+
+    fun setOnImeBackListener(listener: AztecText.OnImeBackListener) {
+        this.onImeBackListener = listener
+    }
+
+    override fun onKeyPreIme(keyCode: Int, event: KeyEvent): Boolean {
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
+            onImeBackListener?.onImeBack()
+        }
+        return super.onKeyPreIme(keyCode, event)
     }
 }


### PR DESCRIPTION
### Fix #193 

Disallow the native full-screen edit mode in landscape and instead, hide the actionbar when the keyboard is shown.

Known issues: undo/redo get hidden since the actionbar gets hidden. This should be fixed with a design change.

### Test
1. Use the demo app in landscape
2. Tap inside the editor
3. The actionbar get hidden while the editor is still available with all the formatting shown and available.
