### PR TITLE
Issue/189 corrupted emoji

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -623,7 +623,7 @@ class AztecParser {
                     val d = text[i + 1]
                     if (d.toInt() >= 0xDC00 && d.toInt() <= 0xDFFF) {
                         i++
-                        val codepoint = 0x010000 or c.toInt() - 0xD800 shl 10 or d.toInt() - 0xDC00
+                        val codepoint = 0x010000 or ((c.toInt() - 0xD800) shl 10) or (d.toInt() - 0xDC00)
                         out.append("&#").append(codepoint).append(";")
                     }
                 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecParserTest.kt
@@ -65,6 +65,7 @@ class AztecParserTest : AndroidTestCase() {
             "<div><span>1</span><br><div>2</div>3<span></span><br>4</div><br><br>5<br><br><div></div>"
     private val HTML_NESTED_INLINE = "<u><i><b>Nested</b></i></u>"
     private val HTML_HIDDEN_WITH_NO_TEXT = "<br><br><div></div><br><br>"
+    private val HTML_EMOJI = "&#128077;&#10084;" // Thumbsup + heart
 
     private val SPAN_BOLD = "Bold\n\n"
     private val SPAN_LIST_ORDERED = "Ordered\n\n"
@@ -120,7 +121,8 @@ class AztecParserTest : AndroidTestCase() {
                 HTML_NESTED_EMPTY_START +
                 HTML_NESTED_EMPTY +
                 HTML_NESTED_WITH_TEXT +
-                HTML_NESTED_INTERLEAVING
+                HTML_NESTED_INTERLEAVING +
+                HTML_EMOJI
 
         val span = SpannableString(mParser.fromHtml(input, context))
         val output = mParser.toHtml(span)


### PR DESCRIPTION
### Fix #189

The AztecParser's unicode codepoint calculation was flawed. This PR fixes it.

### Test
1. Set the `EXAMPLE` val `MainActivity.kt` to `"&#x1F44D;&#x2764;"` and run the demo app. The app should display a "thumbs up" and a "heart" emoji
2. Switch to HTML mode and observe the "thumbs up" and "heart" being there
3. Switch back to visual mode and observe the "thumbs up" and "heart" being there

