### PR TITLE
Cursor positioned while composing html output

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -69,6 +69,7 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
                 "<br>"
         private val CODE = "<code>if (value == 5) printf(value)</code><br>"
         private val IMG = "<img src=\"https://cloud.githubusercontent.com/assets/3827611/21950131/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" />"
+        private val EMOJI = "aaa&#x1F44D;&#x2764;ccc"
         private val EXAMPLE =
                 IMG +
                 HEADING +
@@ -85,7 +86,8 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
                 COMMENT_MORE +
                 COMMENT_PAGE +
                 CODE +
-                UNKNOWN
+                UNKNOWN +
+                EMOJI
     }
 
     private val MEDIA_CAMERA_PHOTO_PERMISSION_REQUEST_CODE: Int = 1001

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
         private val ITALIC = "<i>Italic</i><br>"
         private val UNDERLINE = "<u>Underline</u><br>"
         private val STRIKETHROUGH = "<s class=\"test\">Strikethrough</s><br>" // <s> or <strike> or <del>
-        private val ORDERED = "<ol><li>Ordered</li></ol>"
+        private val ORDERED = "<ol><li>Ordered</li><li></li></ol>"
         private val UNORDERED = "<ul><li>Unordered</li><li></li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"
         private val LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a><br>"

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -47,7 +47,7 @@ class MainActivity : AppCompatActivity(), OnMediaOptionSelectedListener, OnReque
         private val UNDERLINE = "<u>Underline</u><br>"
         private val STRIKETHROUGH = "<s class=\"test\">Strikethrough</s><br>" // <s> or <strike> or <del>
         private val ORDERED = "<ol><li>Ordered</li></ol>"
-        private val UNORDERED = "<ul><li>Unordered</li></ul>"
+        private val UNORDERED = "<ul><li>Unordered</li><li></li></ul>"
         private val QUOTE = "<blockquote>Quote</blockquote>"
         private val LINK = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a><br>"
         private val UNKNOWN = "<iframe class=\"classic\">Menu</iframe><br>"

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -262,6 +262,8 @@ class AztecParser {
             }
             i = next
         }
+
+        consumeCursorIfThere(out, text, text.length)
     }
 
     private fun withinUnknown(out: StringBuilder, text: Spanned, start: Int, end: Int, unknownHtmlSpan: UnknownHtmlSpan) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -318,6 +318,10 @@ class AztecParser {
             }
 
             withinContent(out, text.subSequence(start..newEnd) as Spanned, lineStart, lineEnd)
+
+            // attempt to consume the cursor here to cater for an empty list item
+            consumeCursorIfThere(out, text, itemSpanStart)
+
             out.append("</li>")
         }
         out.append("</${list.getEndTag()}>")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -600,7 +600,7 @@ class AztecParser {
      * Cursor is removed from the input if found at that position.
      *
      * The algorithm that uses this function goes like this: While traversing the input (spannable) string and producing
-     *   the output chunk chunk, look for the cursor span in the input string at a location before or after the chunk.
+     *   the output chunk by chunk, look for the cursor span in the input string at a location before or after the chunk.
      *   If cursor is found then remove it while appending a cursor literal to the output string. This way, the cursor
      *   gets inserted without the need to know which position in the output string corresponds to the position in the
      *   input string.

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -613,7 +613,7 @@ class AztecText : EditText, TextWatcher {
 
         clearMetaSpans(output)
 
-        if (withCursorTag && selectionEnd > 0) {
+        if (withCursorTag) {
             output.setSpan(AztecCursorSpan(), selectionEnd, selectionEnd, Spanned.SPAN_MARK_MARK)
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -171,9 +171,21 @@ class SourceViewEditText : EditText, TextWatcher {
     }
 
     fun consumeCursorTag(styledHtml: SpannableStringBuilder): Int {
-        val cursorTagIndex = styledHtml.indexOf(AztecCursorSpan.AZTEC_CURSOR_TAG)
+        var cursorTagIndex = styledHtml.indexOf(AztecCursorSpan.AZTEC_CURSOR_TAG)
         if (cursorTagIndex < 0) return 0
+
+        val newlineBefore = if (cursorTagIndex > 0) styledHtml[cursorTagIndex - 1] == '\n' else false
+        val newlineAfter = if (cursorTagIndex + AztecCursorSpan.AZTEC_CURSOR_TAG.length + 1 < styledHtml.length)
+            styledHtml[cursorTagIndex + AztecCursorSpan.AZTEC_CURSOR_TAG.length] == '\n' else false
+
         styledHtml.delete(cursorTagIndex, cursorTagIndex + AztecCursorSpan.AZTEC_CURSOR_TAG.length)
+
+        if (newlineBefore && newlineAfter) {
+            cursorTagIndex--;
+
+            // remove one of the newlines as those are an artefact of the extra formatting applied around the cursor marker
+            styledHtml.delete(cursorTagIndex, cursorTagIndex + 1)
+        }
 
         //if something went wrong make sure to remove cursor tag
         styledHtml.replace(AztecCursorSpan.AZTEC_CURSOR_TAG.toRegex(), "")


### PR DESCRIPTION
### Fix #209 

Instead of trying to place the cursor at the html output after having outputted the spans and characters, place the cursor while traversing the input. This way, we don't need to know the output size of each element/character and we don't need to compute the output cursor position.

Known issues: undo/redo doesn't preserve the cursor position while switching to html. That's an issue prior to this PR anyway.

### Test
1. In the demo app, place the cursor anywhere inside the visual editor
2. Switch to html mode and observe the position of the cursor. It should be "preserved" staying in a position relevant to the visual mode position
3. While at it, notice that even placing the cursor around emojis and switching to html mode, emojis are preserved
