### PR TITLE
Issue/211 inline format selection

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -407,10 +407,7 @@ class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(
                 }
             }
 
-            val selectedText = editableText.subSequence(start, end).toString().replace("\n", "")
-            val styledText = builder.toString()
-
-            return !styledText.isEmpty() && selectedText.contains(styledText)
+            return editableText.subSequence(start, end).toString() == builder.toString()
         }
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/AztecToolbarTest.kt
@@ -288,7 +288,7 @@ class AztecToolbarTest {
     }
 
     /**
-     * Test toggle state of formatting button as we move selection to differently styled text
+     * Test toggle state of formatting button as selection moves to differently styled text.
      *
      * @throws Exception
      */
@@ -312,7 +312,7 @@ class AztecToolbarTest {
         //bold and bold/italic styles selected
         editText.setSelection(2, 7)
         Assert.assertTrue(boldButton.isChecked)
-        Assert.assertTrue(italicButton.isChecked)
+        Assert.assertFalse(italicButton.isChecked)
         Assert.assertFalse(strikeThroughButton.isChecked)
 
         //cursor is at italic text
@@ -335,20 +335,21 @@ class AztecToolbarTest {
 
         //whole text selected
         editText.setSelection(0, editText.length() - 1)
-        Assert.assertTrue(boldButton.isChecked)
-        Assert.assertTrue(italicButton.isChecked)
-        Assert.assertTrue(strikeThroughButton.isChecked)
+        Assert.assertFalse(boldButton.isChecked)
+        Assert.assertFalse(italicButton.isChecked)
+        Assert.assertFalse(strikeThroughButton.isChecked)
     }
 
     /**
-     * Select whole text with one common style applied to it and another style applied to part of it
-     * ("di" from <b>bold</b><b><i>italic</i></b>) and extend partially applied style (italic) to other part of selection
+     * Select part of text with one common style (bold) applied to it and another style (italic)
+     * applied to part of it ("di" from <b>bold</b><b><i>italic</i></b>) and extend partially
+     * applied style (italic) to other part of selection.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun removeStyleItalicPartialSelection() {
+    fun extendStyleItalicPartialSelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
 
         val selectedText = editText.text.substring(3, 5)
@@ -356,21 +357,22 @@ class AztecToolbarTest {
 
         editText.setSelection(3, 5)
         Assert.assertTrue(boldButton.isChecked)
-        Assert.assertTrue(italicButton.isChecked)
+        Assert.assertFalse(italicButton.isChecked)
 
         italicButton.performClick()
-        Assert.assertEquals("<b>boldi</b><b><i>talic</i></b>", editText.toHtml())
+        Assert.assertEquals("<b>bol</b><b><i>ditalic</i></b>", editText.toHtml())
     }
 
     /**
-     * Select whole text with one common style applied to it and another style applied to part of it
-     * ("ds" from <b>bold</b><b><del>strike</del></b>) and extend partially applied style (strikethrough) to other part of selection
+     * Select part of text with one common style applied to it (bold) and another style (strikethrough)
+     * applied to part of it ("ds" from <b>bold</b><b><del>strike</del></b>) and extend partially
+     * applied style (strikethrough) to other part of selection.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun removeStyleStrikethroughPartialSelection() {
+    fun extendStyleStrikethroughPartialSelection() {
         editText.fromHtml("<b>bold</b><b><del>strike</del></b>")
 
         val selectedText = editText.text.substring(3, 5)
@@ -378,21 +380,22 @@ class AztecToolbarTest {
 
         editText.setSelection(3, 5)
         Assert.assertTrue(boldButton.isChecked)
-        Assert.assertTrue(strikeThroughButton.isChecked)
+        Assert.assertFalse(strikeThroughButton.isChecked)
 
         strikeThroughButton.performClick()
-        Assert.assertEquals("<b>bolds</b><b><del>trike</del></b>", editText.toHtml())
+        Assert.assertEquals("<b>bol</b><b><del>dstrike</del></b>", editText.toHtml())
     }
 
     /**
-     * Select part of text with one common style applied to it and other style applied to part of it
-     * ("italic" from <b>bold</b><b><i>italic</i></b>) and remove partially applied style (italic) form it
+     * Select part of text with one common style applied (bold) to it and other style (italic)
+     * applied to part of it ("italic" from <b>bold</b><b><i>italic</i></b>) and extend partially
+     * applied style (italic) to other part of selection.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun removeStyleFromPartialSelection() {
+    fun extendStyleFromPartialSelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
 
         val selectedText = editText.text.substring(4, editText.length())
@@ -406,24 +409,24 @@ class AztecToolbarTest {
     }
 
     /**
-     * Select whole text with one common style applied to it and another style applied to part of it
-     * extend partial style (italic) to whole selection
+     * Select whole text with one common style (bold) applied to it and another style (italic)
+     * applied to part of it and extend partial style (italic) to whole selection.
      *
      * @throws Exception
      */
     @Test
     @Throws(Exception::class)
-    fun removeStyleFromWholeSelection() {
+    fun extendStyleFromWholeSelection() {
         editText.fromHtml("<b>bold</b><b><i>italic</i></b>")
 
         editText.setSelection(0, editText.length())
 
         italicButton.performClick()
-        Assert.assertEquals("<b>bolditalic</b>", editText.toHtml())
+        Assert.assertEquals("<b><i>bolditalic</i></b>", editText.toHtml())
     }
 
     /**
-     * Select whole text inside editor and remove styles from it while maintaining selection.
+     * Select whole text inside editor and remove/add styles while maintaining selection.
      *
      * @throws Exception
      */
@@ -438,13 +441,13 @@ class AztecToolbarTest {
         Assert.assertEquals("bold<i>italic</i>", editText.toHtml())
 
         italicButton.performClick()
-        Assert.assertEquals("bolditalic", editText.toHtml())
-
-        italicButton.performClick()
         Assert.assertEquals("<i>bolditalic</i>", editText.toHtml())
 
+        italicButton.performClick()
+        Assert.assertEquals("bolditalic", editText.toHtml())
+
         boldButton.performClick()
-        Assert.assertEquals("<i><b>bolditalic</b></i>", editText.toHtml())
+        Assert.assertEquals("<b>bolditalic</b>", editText.toHtml())
     }
 
     /**
@@ -492,7 +495,7 @@ class AztecToolbarTest {
     }
 
     /**
-     * Test styling inside HiddenHtmlSpan
+     * Test styling inside HiddenHtmlSpan.
      *
      * @throws Exception
      */
@@ -520,7 +523,7 @@ class AztecToolbarTest {
     }
 
     /**
-     * Test the correctness of span-to-HTML conversion after deleting a span from the editor
+     * Test the correctness of span-to-HTML conversion after deleting a span from the editor.
      *
      * @throws Exception
      */


### PR DESCRIPTION
### Fix
Revert changes made in https://github.com/wordpress-mobile/WordPress-Aztec-Android/pull/159 as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/211.

### Test
Input text and check format toolbar status as shown in the screenshots below.

![01](https://cloud.githubusercontent.com/assets/3827611/21277006/663cb0ce-c391-11e6-9f08-197a01b30996.png)

![02](https://cloud.githubusercontent.com/assets/3827611/21277007/663eb5f4-c391-11e6-83e9-3688a3bdfe07.png)

![03](https://cloud.githubusercontent.com/assets/3827611/21277010/6641235c-c391-11e6-8453-a10989d2d72c.png)

![04](https://cloud.githubusercontent.com/assets/3827611/21277011/66447a5c-c391-11e6-85a9-7e0b6248251d.png)

![05](https://cloud.githubusercontent.com/assets/3827611/21277009/6640f9e0-c391-11e6-9d20-c54b4d5d2ca6.png)

![06](https://cloud.githubusercontent.com/assets/3827611/21277008/663f5068-c391-11e6-9e59-8903b7103594.png)

![07](https://cloud.githubusercontent.com/assets/3827611/21277977/fcc92190-c395-11e6-8cc3-a3b1886c5d03.png)

![08](https://cloud.githubusercontent.com/assets/3827611/21277975/fcc413e4-c395-11e6-9d77-b2eb07751b57.png)

![09](https://cloud.githubusercontent.com/assets/3827611/21277976/fcc8d186-c395-11e6-89d4-85df6c79d36e.png)