### PR TITLE
Cursor at end of non empty list item

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -317,7 +317,7 @@ class AztecParser {
                 out.append("<li>")
             }
 
-            withinContent(out, text.subSequence(start..newEnd) as Spanned, lineStart, lineEnd)
+            withinContent(out, text, start + lineStart, start + lineEnd)
 
             // attempt to consume the cursor here to cater for an empty list item
             consumeCursorIfInInput(out, text, itemSpanStart)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -285,11 +285,8 @@ class AztecParser {
     }
 
     private fun withinList(out: StringBuilder, text: Spanned, start: Int, end: Int, list: AztecListSpan) {
-        val newEnd = end - 1
-        val listContent = text.subSequence(start..newEnd) as Spanned
-
         out.append("<${list.getStartTag()}>")
-        var lines = TextUtils.split(listContent.toString(), "\n")
+        var lines = TextUtils.split(text.substring(start, end), "\n")
 
         if (lines.isNotEmpty() && lines.last().isEmpty()) {
             lines = lines.take(lines.size - 1).toTypedArray()


### PR DESCRIPTION
Changes in a subsequence don't appear in parent. And in this case breaks the algorithm of the cursor migration. E.g. changing the spans in the subsequence doesn't mirror those changes back to the parent spannable string.

Fixes the cursor issue mentioned in https://github.com/wordpress-mobile/WordPress-Aztec-Android/pull/210#pullrequestreview-18965347

### Test
1. Go to the visual view.
2. Put cursor at the end of any list item.
3. Tap the HTML format button. Notice the erroneous "aztec_cursor" is no longer there.

### Review
@theck13 want to pick this up as well? Cheers!
