### PR TITLE
Issue/5041 disable toolbar buttons

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -312,7 +312,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         return null
     }
 
-    private fun toggleHtmlMode(isHtmlMode: Boolean) {
+    fun toggleHtmlMode(isHtmlMode: Boolean) {
         ToolbarAction.values().forEach { action ->
             if (action == ToolbarAction.HTML) {
                 toggleButton(findViewById(action.buttonId), isHtmlMode)
@@ -321,12 +321,6 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
             }
         }
 	}
-
-    fun toggleFormatButtons(isEnabled: Boolean) {
-        ToolbarAction.values().forEach { action ->
-            toggleButtonState(findViewById(action.buttonId), isEnabled)
-        }
-    }
 
     private fun showMediaUploadDialog() {
         if (!isEditorAttached()) return

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -258,7 +258,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                 editor!!.visibility = View.GONE
                 sourceEditor!!.visibility = View.VISIBLE
 
-                toggleHtmlMode(true)
+                enableFormatToolbar(false)
             } else {
                 toggleButton(findViewById(ToolbarAction.HTML.buttonId), false)
                 showMediaUploadDialog()
@@ -268,7 +268,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
             editor!!.visibility = View.VISIBLE
             sourceEditor!!.visibility = View.GONE
 
-            toggleHtmlMode(false)
+            enableFormatToolbar(true)
         }
     }
 
@@ -312,12 +312,12 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         return null
     }
 
-    fun toggleHtmlMode(isHtmlMode: Boolean) {
+    fun enableFormatToolbar(isEnabled: Boolean) {
         ToolbarAction.values().forEach { action ->
             if (action == ToolbarAction.HTML) {
-                toggleButton(findViewById(action.buttonId), isHtmlMode)
+                toggleButton(findViewById(action.buttonId), !isEnabled)
             } else {
-                toggleButtonState(findViewById(action.buttonId), !isHtmlMode)
+                toggleButtonState(findViewById(action.buttonId), isEnabled)
             }
         }
 	}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -258,7 +258,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                 editor!!.visibility = View.GONE
                 sourceEditor!!.visibility = View.VISIBLE
 
-                enableFormatToolbar(false)
+                enableFormatButtons(false)
             } else {
                 toggleButton(findViewById(ToolbarAction.HTML.buttonId), false)
                 showMediaUploadDialog()
@@ -268,7 +268,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
             editor!!.visibility = View.VISIBLE
             sourceEditor!!.visibility = View.GONE
 
-            enableFormatToolbar(true)
+            enableFormatButtons(true)
         }
     }
 
@@ -312,7 +312,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         return null
     }
 
-    fun enableFormatToolbar(isEnabled: Boolean) {
+    fun enableFormatButtons(isEnabled: Boolean) {
         ToolbarAction.values().forEach { action ->
             if (action == ToolbarAction.HTML) {
                 toggleButton(findViewById(action.buttonId), !isEnabled)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -322,6 +322,12 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         }
 	}
 
+    fun toggleFormatButtons(isEnabled: Boolean) {
+        ToolbarAction.values().forEach { action ->
+            toggleButtonState(findViewById(action.buttonId), isEnabled)
+        }
+    }
+
     private fun showMediaUploadDialog() {
         if (!isEditorAttached()) return
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -258,7 +258,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
                 editor!!.visibility = View.GONE
                 sourceEditor!!.visibility = View.VISIBLE
 
-                enableFormatButtons(false)
+                toggleHtmlMode(true)
             } else {
                 toggleButton(findViewById(ToolbarAction.HTML.buttonId), false)
                 showMediaUploadDialog()
@@ -268,7 +268,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
             editor!!.visibility = View.VISIBLE
             sourceEditor!!.visibility = View.GONE
 
-            enableFormatButtons(true)
+            toggleHtmlMode(false)
         }
     }
 
@@ -312,15 +312,23 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         return null
     }
 
-    fun enableFormatButtons(isEnabled: Boolean) {
+    private fun toggleHtmlMode(isHtmlMode: Boolean) {
         ToolbarAction.values().forEach { action ->
             if (action == ToolbarAction.HTML) {
-                toggleButton(findViewById(action.buttonId), !isEnabled)
+                toggleButton(findViewById(action.buttonId), isHtmlMode)
             } else {
-                toggleButtonState(findViewById(action.buttonId), isEnabled)
+                toggleButtonState(findViewById(action.buttonId), !isHtmlMode)
             }
         }
 	}
+
+    fun enableFormatButtons(isEnabled: Boolean) {
+        ToolbarAction.values().forEach { action ->
+            if (action != ToolbarAction.HTML) {
+                toggleButtonState(findViewById(action.buttonId), isEnabled)
+            }
+        }
+    }
 
     private fun showMediaUploadDialog() {
         if (!isEditorAttached()) return


### PR DESCRIPTION
### Fix
Add method to enable/disable toolbar buttons excluding the HTML button for use in resolving https://github.com/wordpress-mobile/WordPress-Android/issues/5041.

### Test
The best test is in the [`feature\aztec-integration`](https://github.com/wordpress-mobile/WordPress-Android/tree/feature/aztec-integration) branch.  Add `compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:issue~5041-disable-toolbar-buttons-SNAPSHOT')` to the dependencies in the `build.gradle` file and add something like this to the `AztecEditorFragment` file.

```
title = (AztecText) view.findViewById(R.id.title);
final AztecToolbar toolbar = (AztecToolbar) view.findViewById(R.id.formatting_toolbar);

title.setOnFocusChangeListener(
    new View.OnFocusChangeListener() {
        @Override
        public void onFocusChange(View view, boolean hasFocus) {
            toolbar.enableFormatButtons(!hasFocus);
        }
    }
);
```