### PR TITLE
Issue/162 adding padding to block elements

### DIFF
--- a/aztec/src/main/java/org/wordpress/aztec/Html.java
+++ b/aztec/src/main/java/org/wordpress/aztec/Html.java
@@ -41,7 +41,7 @@ import org.wordpress.aztec.spans.AztecCodeSpan;
 import org.wordpress.aztec.spans.AztecCommentSpan;
 import org.wordpress.aztec.spans.AztecContentSpan;
 import org.wordpress.aztec.spans.AztecCursorSpan;
-import org.wordpress.aztec.spans.AztecListSpan;
+import org.wordpress.aztec.spans.AztecHeadingSpan;
 import org.wordpress.aztec.spans.AztecRelativeSizeSpan;
 import org.wordpress.aztec.spans.AztecStyleSpan;
 import org.wordpress.aztec.spans.AztecSubscriptSpan;
@@ -473,7 +473,7 @@ class HtmlToSpannedConverter implements ContentHandler, LexicalHandler {
         // Fix flags and range for paragraph-type markup.
         Object[] obj = spannableStringBuilder.getSpans(0, spannableStringBuilder.length(), ParagraphStyle.class);
         for (int i = 0; i < obj.length; i++) {
-            if (obj[i] instanceof UnknownHtmlSpan || obj[i] instanceof AztecBlockSpan) {
+            if (obj[i] instanceof UnknownHtmlSpan || obj[i] instanceof AztecBlockSpan || obj[i] instanceof AztecHeadingSpan) {
                 continue;
             }
             int start = spannableStringBuilder.getSpanStart(obj[i]);

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecParser.kt
@@ -25,7 +25,6 @@ import android.text.Spanned
 import android.text.TextUtils
 import android.text.style.CharacterStyle
 import android.text.style.ImageSpan
-import android.text.style.ParagraphStyle
 import org.wordpress.aztec.spans.*
 import java.util.*
 
@@ -231,9 +230,9 @@ class AztecParser {
         var i = 0
 
         while (i < text.length) {
-            next = text.nextSpanTransition(i, text.length, ParagraphStyle::class.java)
+            next = text.nextSpanTransition(i, text.length, AztecParagraphStyle::class.java)
 
-            val styles = text.getSpans(i, next, ParagraphStyle::class.java)
+            val styles = text.getSpans(i, next, AztecParagraphStyle::class.java)
 
             if (styles.size == 2) {
                 if (styles[0] is AztecListSpan && styles[1] is AztecQuoteSpan) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -126,7 +126,9 @@ class AztecText : EditText, TextWatcher {
         inlineFormatter = InlineFormatter(this,
                 InlineFormatter.CodeStyle(
                         array.getColor(R.styleable.AztecText_codeBackground, 0),
-                        array.getColor(R.styleable.AztecText_codeColor, 0)))
+                        array.getColor(R.styleable.AztecText_codeColor, 0)),
+                LineBlockFormatter.HeaderStyle(
+                        array.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0)))
 
         blockFormatter = BlockFormatter(this,
                 BlockFormatter.ListStyle(
@@ -148,7 +150,8 @@ class AztecText : EditText, TextWatcher {
                 R.styleable.AztecText_linkColor, 0),
                 array.getBoolean(R.styleable.AztecText_linkUnderline, true)))
 
-        lineBlockFormatter = LineBlockFormatter(this, array.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0))
+        lineBlockFormatter = LineBlockFormatter(this, LineBlockFormatter.HeaderStyle(
+                array.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0)))
 
         array.recycle()
 
@@ -674,7 +677,8 @@ class AztecText : EditText, TextWatcher {
             val spanStart = editable.getSpanStart(it)
             val spanEnd = editable.getSpanEnd(it)
             editable.removeSpan(it)
-            editable.setSpan(AztecHeadingSpan(it.textFormat, it.attributes, lineBlockFormatter.verticlPadding), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+            editable.setSpan(AztecHeadingSpan(it.textFormat, it.attributes,
+                    lineBlockFormatter.headerStyle.verticalPadding), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -212,8 +212,10 @@ class AztecText : EditText, TextWatcher {
         val retainedSelectionStart = customState.getInt("selection_start")
         val retainedSelectionEnd = customState.getInt("selection_end")
 
-        if (retainedSelectionEnd < editableText.length)
+        if (retainedSelectionEnd < editableText.length){
             setSelection(retainedSelectionStart, retainedSelectionEnd)
+        }
+
 
 
         val isDialogVisible = customState.getBoolean("isUrlDialogVisible", false)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -136,13 +136,15 @@ class AztecText : EditText, TextWatcher {
                         array.getColor(R.styleable.AztecText_bulletColor, 0),
                         array.getDimensionPixelSize(R.styleable.AztecText_bulletMargin, 0),
                         array.getDimensionPixelSize(R.styleable.AztecText_bulletPadding, 0),
-                        array.getDimensionPixelSize(R.styleable.AztecText_bulletWidth, 0)),
+                        array.getDimensionPixelSize(R.styleable.AztecText_bulletWidth, 0),
+                        array.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0)),
                 BlockFormatter.QuoteStyle(
                         array.getColor(R.styleable.AztecText_quoteBackground, 0),
                         array.getColor(R.styleable.AztecText_quoteColor, 0),
                         array.getDimensionPixelSize(R.styleable.AztecText_quoteMargin, 0),
                         array.getDimensionPixelSize(R.styleable.AztecText_quotePadding, 0),
-                        array.getDimensionPixelSize(R.styleable.AztecText_quoteWidth, 0)
+                        array.getDimensionPixelSize(R.styleable.AztecText_quoteWidth, 0),
+                        array.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0)
                 ))
 
         linkFormatter = LinkFormatter(this, LinkFormatter.LinkStyle(array.getColor(

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -76,7 +76,7 @@ class AztecText : EditText, TextWatcher {
 
     lateinit var inlineFormatter: InlineFormatter
     lateinit var blockFormatter: BlockFormatter
-    val lineBlockFormatter: LineBlockFormatter
+    lateinit var lineBlockFormatter: LineBlockFormatter
     lateinit var linkFormatter: LinkFormatter
 
     var imageGetter: Html.ImageGetter? = null
@@ -89,9 +89,6 @@ class AztecText : EditText, TextWatcher {
         fun onImeBack()
     }
 
-    init {
-        lineBlockFormatter = LineBlockFormatter(this)
-    }
 
     constructor(context: Context) : super(context) {
         init(null)
@@ -150,6 +147,8 @@ class AztecText : EditText, TextWatcher {
         linkFormatter = LinkFormatter(this, LinkFormatter.LinkStyle(array.getColor(
                 R.styleable.AztecText_linkColor, 0),
                 array.getBoolean(R.styleable.AztecText_linkUnderline, true)))
+
+        lineBlockFormatter = LineBlockFormatter(this, array.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0))
 
         array.recycle()
 
@@ -212,10 +211,9 @@ class AztecText : EditText, TextWatcher {
         val retainedSelectionStart = customState.getInt("selection_start")
         val retainedSelectionEnd = customState.getInt("selection_end")
 
-        if (retainedSelectionEnd < editableText.length){
+        if (retainedSelectionEnd < editableText.length) {
             setSelection(retainedSelectionStart, retainedSelectionEnd)
         }
-
 
 
         val isDialogVisible = customState.getBoolean("isUrlDialogVisible", false)
@@ -669,6 +667,14 @@ class AztecText : EditText, TextWatcher {
             val spanEnd = editable.getSpanEnd(it)
             editable.removeSpan(it)
             editable.setSpan(inlineFormatter.makeInlineSpan(it.javaClass, it.attributes), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        val headingSpan = editable.getSpans(start, end, AztecHeadingSpan::class.java)
+        headingSpan.forEach {
+            val spanStart = editable.getSpanStart(it)
+            val spanEnd = editable.getSpanEnd(it)
+            editable.removeSpan(it)
+            editable.setSpan(AztecHeadingSpan(it.textFormat, it.attributes, lineBlockFormatter.verticlPadding), spanStart, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -212,7 +212,8 @@ class AztecText : EditText, TextWatcher {
         val retainedSelectionStart = customState.getInt("selection_start")
         val retainedSelectionEnd = customState.getInt("selection_end")
 
-        setSelection(retainedSelectionStart, retainedSelectionEnd)
+        if (retainedSelectionEnd < editableText.length)
+            setSelection(retainedSelectionStart, retainedSelectionEnd)
 
 
         val isDialogVisible = customState.getBoolean("isUrlDialogVisible", false)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -13,8 +13,8 @@ import java.util.*
 
 class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteStyle) : AztecFormatter(editor) {
 
-    data class ListStyle(val indicatorColor: Int, val indicatorMargin: Int, val indicatorPadding: Int, val indicatorWidth: Int)
-    data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int)
+    data class ListStyle(val indicatorColor: Int, val indicatorMargin: Int, val indicatorPadding: Int, val indicatorWidth: Int, val verticalPadding: Int)
+    data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
 
     val listStyle: ListStyle
     val quoteStyle: QuoteStyle

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -55,7 +55,7 @@ class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(
         }
     }
 
-    fun toggleCode(){
+    fun toggleCode() {
         if (!containsInlineStyle(TextFormat.FORMAT_CODE)) {
             applyInlineStyle(TextFormat.FORMAT_CODE)
         } else {
@@ -356,7 +356,7 @@ class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(
             TextFormat.FORMAT_HEADING_3,
             TextFormat.FORMAT_HEADING_4,
             TextFormat.FORMAT_HEADING_5,
-            TextFormat.FORMAT_HEADING_6 -> return AztecHeadingSpan(textFormat)
+            TextFormat.FORMAT_HEADING_6 -> return AztecHeadingSpan(textFormat, "", editor.lineBlockFormatter.verticlPadding)
             TextFormat.FORMAT_BOLD -> return AztecStyleSpan(Typeface.BOLD)
             TextFormat.FORMAT_ITALIC -> return AztecStyleSpan(Typeface.ITALIC)
             TextFormat.FORMAT_STRIKETHROUGH -> return AztecStrikethroughSpan()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -11,17 +11,13 @@ import org.wordpress.aztec.spans.*
 import java.util.*
 
 
-class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(editor) {
+class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, val headerStyle: LineBlockFormatter.HeaderStyle) : AztecFormatter(editor) {
 
     data class CarryOverSpan(val span: AztecInlineSpan, val start: Int, val end: Int)
     data class CodeStyle(val codeBackground: Int, val codeColor: Int)
 
     val carryOverSpans = ArrayList<CarryOverSpan>()
-    val codeStyle: CodeStyle
 
-    init {
-        this.codeStyle = codeStyle
-    }
 
     fun toggleBold() {
         if (!containsInlineStyle(TextFormat.FORMAT_BOLD)) {
@@ -356,7 +352,7 @@ class InlineFormatter(editor: AztecText, codeStyle: CodeStyle) : AztecFormatter(
             TextFormat.FORMAT_HEADING_3,
             TextFormat.FORMAT_HEADING_4,
             TextFormat.FORMAT_HEADING_5,
-            TextFormat.FORMAT_HEADING_6 -> return AztecHeadingSpan(textFormat, "", editor.lineBlockFormatter.verticlPadding)
+            TextFormat.FORMAT_HEADING_6 -> return AztecHeadingSpan(textFormat, "", headerStyle.verticalPadding)
             TextFormat.FORMAT_BOLD -> return AztecStyleSpan(Typeface.BOLD)
             TextFormat.FORMAT_ITALIC -> return AztecStyleSpan(Typeface.ITALIC)
             TextFormat.FORMAT_STRIKETHROUGH -> return AztecStrikethroughSpan()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -12,7 +12,7 @@ import org.wordpress.aztec.spans.*
 import java.util.*
 
 
-class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
+class LineBlockFormatter(editor: AztecText, val verticlPadding: Int) : AztecFormatter(editor) {
 
     fun applyHeading(textFormat: TextFormat) {
         headingClear()
@@ -48,7 +48,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
                     editableText.setSpan(spanAtNewLIne, spanStart + 1, spanEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                 } else if (!isHeadingSplitRequired && editableText.length > textChangedEvent.inputStart + 1 && editableText[textChangedEvent.inputStart + 1] == '\n') {
                     editableText.setSpan(spanAtNewLIne, spanStart, spanEnd - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-                } else if(!isHeadingSplitRequired && textChangedEvent.inputStart + 1 == spanEnd && editableText[textChangedEvent.inputStart] == '\n'){
+                } else if (!isHeadingSplitRequired && textChangedEvent.inputStart + 1 == spanEnd && editableText[textChangedEvent.inputStart] == '\n') {
                     editableText.setSpan(spanAtNewLIne, spanStart, spanEnd - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
                 }
             }
@@ -135,7 +135,7 @@ class LineBlockFormatter(editor: AztecText) : AztecFormatter(editor) {
             }
 
             if (headingStart < headingEnd) {
-                editableText.setSpan(AztecHeadingSpan(textFormat), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                editableText.setSpan(AztecHeadingSpan(textFormat, "", verticlPadding), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/LineBlockFormatter.kt
@@ -12,7 +12,9 @@ import org.wordpress.aztec.spans.*
 import java.util.*
 
 
-class LineBlockFormatter(editor: AztecText, val verticlPadding: Int) : AztecFormatter(editor) {
+class LineBlockFormatter(editor: AztecText, val headerStyle: LineBlockFormatter.HeaderStyle) : AztecFormatter(editor) {
+
+    data class HeaderStyle(val verticalPadding: Int)
 
     fun applyHeading(textFormat: TextFormat) {
         headingClear()
@@ -135,7 +137,7 @@ class LineBlockFormatter(editor: AztecText, val verticlPadding: Int) : AztecForm
             }
 
             if (headingStart < headingEnd) {
-                editableText.setSpan(AztecHeadingSpan(textFormat, "", verticlPadding), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                editableText.setSpan(AztecHeadingSpan(textFormat, "", headerStyle.verticalPadding), headingStart, headingEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecBlockSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecBlockSpan.kt
@@ -1,4 +1,4 @@
 package org.wordpress.aztec.spans
 
 
-interface AztecBlockSpan : AztecContentSpan, AztecLineBlockSpan
+interface AztecBlockSpan : AztecContentSpan, AztecLineBlockSpan, AztecParagraphStyle

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -1,14 +1,22 @@
 package org.wordpress.aztec.spans
 
+import android.graphics.Paint
+import android.text.Spanned
 import android.text.TextPaint
 import android.text.TextUtils
+import android.text.style.LineHeightSpan
 import android.text.style.MetricAffectingSpan
+import android.text.style.UpdateLayout
 import org.wordpress.aztec.TextFormat
 
-class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, attrs: String = "") : MetricAffectingSpan(), AztecLineBlockSpan, AztecContentSpan, AztecInlineSpan {
+class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, attrs: String = "", val verticalPadding: Int = 0) : MetricAffectingSpan(),
+        AztecLineBlockSpan, AztecContentSpan, AztecInlineSpan, LineHeightSpan, UpdateLayout {
 
     lateinit var heading: Heading
     override var attributes: String = attrs
+
+    var previousFontMetrics: Paint.FontMetricsInt? = null
+    var previousTextScale: Float = 1.0f
 
     companion object {
         private val SCALE_H1: Float = 1.73f
@@ -31,7 +39,42 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
         }
     }
 
-    constructor(tag: String, attrs: String = "") : this(getTextFormat(tag), attrs) {
+    constructor(tag: String, attrs: String = "", verticalPadding: Int = 0) : this(getTextFormat(tag), attrs, verticalPadding)
+
+    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        val spanEnd = spanned.getSpanEnd(this)
+
+        if (previousFontMetrics == null) {
+            previousFontMetrics = Paint.FontMetricsInt()
+            previousFontMetrics!!.top = fm.top
+            previousFontMetrics!!.ascent = fm.ascent
+            previousFontMetrics!!.bottom = fm.bottom
+            previousFontMetrics!!.descent = fm.descent
+        }
+
+        var addedTopPadding = false
+        var addedBottomPadding = false
+
+        if (start == spanStart || start < spanStart) {
+            fm.ascent -= verticalPadding
+            fm.top -= verticalPadding
+            addedTopPadding = true
+        }
+        if (end == spanEnd || spanEnd < end) {
+            fm.descent += verticalPadding
+            fm.bottom += verticalPadding
+            addedBottomPadding = true
+        }
+
+        if (!addedTopPadding && !addedBottomPadding) {
+            fm.ascent = previousFontMetrics!!.ascent
+            fm.top = previousFontMetrics!!.top
+            fm.descent = previousFontMetrics!!.descent
+            fm.bottom = previousFontMetrics!!.bottom
+        }
+
 
     }
 
@@ -61,6 +104,11 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
     }
 
     override fun updateMeasureState(textPaint: TextPaint) {
+        if (previousTextScale != heading.scale) {
+            previousFontMetrics = null
+        }
+        previousTextScale = heading.scale
+
         textPaint.textSize *= heading.scale
     }
 
@@ -96,6 +144,6 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
     }
 
     override fun clone(): Any {
-        return AztecHeadingSpan(textFormat, attributes)
+        return AztecHeadingSpan(textFormat, attributes, verticalPadding)
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -9,7 +9,7 @@ import android.text.style.MetricAffectingSpan
 import android.text.style.UpdateLayout
 import org.wordpress.aztec.TextFormat
 
-class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, attrs: String = "", val verticalPadding: Int = 0) : MetricAffectingSpan(),
+class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, attrs: String = "", val verticalPadding: Int) : MetricAffectingSpan(),
         AztecLineBlockSpan, AztecContentSpan, AztecInlineSpan, LineHeightSpan, UpdateLayout {
 
     lateinit var heading: Heading

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -46,6 +46,7 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
+        //save original font metrics
         if (previousFontMetrics == null) {
             previousFontMetrics = Paint.FontMetricsInt()
             previousFontMetrics!!.top = fm.top
@@ -68,6 +69,7 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
             addedBottomPadding = true
         }
 
+        //apply original font metrics to lines that should not have vertical padding
         if (!addedTopPadding && !addedBottomPadding) {
             fm.ascent = previousFontMetrics!!.ascent
             fm.top = previousFontMetrics!!.top
@@ -104,6 +106,7 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
     }
 
     override fun updateMeasureState(textPaint: TextPaint) {
+        //when font size changes - reset cached font metrics to reapply vertical padding
         if (previousTextScale != heading.scale) {
             previousFontMetrics = null
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecHeadingSpan.kt
@@ -70,13 +70,15 @@ class AztecHeadingSpan @JvmOverloads constructor(var textFormat: TextFormat, att
         }
 
         //apply original font metrics to lines that should not have vertical padding
-        if (!addedTopPadding && !addedBottomPadding) {
+        if (!addedTopPadding) {
             fm.ascent = previousFontMetrics!!.ascent
             fm.top = previousFontMetrics!!.top
+        }
+
+        if (!addedBottomPadding) {
             fm.descent = previousFontMetrics!!.descent
             fm.bottom = previousFontMetrics!!.bottom
         }
-
 
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -1,24 +1,59 @@
 package org.wordpress.aztec.spans
 
-import android.os.Parcel
+import android.graphics.Paint
+import android.text.Spanned
 import android.text.style.LeadingMarginSpan
-import org.wordpress.aztec.formatting.BlockFormatter
+import android.text.style.LineHeightSpan
+import android.text.style.UpdateLayout
 
 
-abstract class AztecListSpan : LeadingMarginSpan.Standard, AztecBlockSpan {
+abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Standard(0), AztecBlockSpan, LineHeightSpan, UpdateLayout {
+
+    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        val spanEnd = spanned.getSpanEnd(this)
+
+
+        if (start === spanStart || start < spanStart) {
+            fm.ascent -= verticalPadding
+            fm.top -= verticalPadding
+        }
+        if (end === spanEnd || spanEnd < end) {
+            fm.descent += verticalPadding
+            fm.bottom += verticalPadding
+        }
+    }
+
     abstract var lastItem: AztecListItemSpan
-
-    constructor(listStyle: BlockFormatter.ListStyle, attributes: String, last: AztecListItemSpan) : super(listStyle.indicatorMargin)
-
-    constructor(src: Parcel) : super(src)
-
-    constructor(attributes: String) : super(0)
-
-    constructor() : super(0)
 
     fun getLineNumber(text: CharSequence, end: Int): Int {
         val textBeforeBeforeEnd = text.substring(0, end)
         val lineIndex = textBeforeBeforeEnd.length - textBeforeBeforeEnd.replace("\n", "").length
         return lineIndex + 1
     }
+
+    fun getVerticalPadding(text: CharSequence, end: Int): Int {
+        val spanStart = (text as Spanned).getSpanStart(this)
+        val spanEnd = text.getSpanEnd(this)
+
+        val listText = text.subSequence(spanStart, spanEnd)
+
+        val lineNumber = getLineNumber(listText, end - spanStart)
+
+        var adjustment = 0
+
+        val numberOfLines = text.substring(spanStart..spanEnd - 2).split("\n").count()
+
+        if (numberOfLines > 1 && lineNumber == 1) {
+            adjustment = if (this is AztecOrderedListSpan) 0 else verticalPadding
+        } else if (numberOfLines > 1 && numberOfLines == lineNumber) {
+            adjustment = -verticalPadding
+        } else if (numberOfLines == 1) {
+            adjustment = -verticalPadding
+        }
+
+        return adjustment
+    }
+
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -26,7 +26,7 @@ abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Stand
         }
     }
 
-    fun getNumberOfProcessedLine(text: CharSequence, end: Int): Int {
+    fun getIndexOfProcessedLine(text: CharSequence, end: Int): Int {
         val spanStart = (text as Spanned).getSpanStart(this)
         val spanEnd = text.getSpanEnd(this)
 
@@ -48,7 +48,7 @@ abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Stand
         var adjustment = 0
 
         val totalNumberOfLinesInList = getTotalNumberOfLines(text)
-        val currentLineNumber = getNumberOfProcessedLine(text, end)
+        val currentLineNumber = getIndexOfProcessedLine(text, end)
 
         if (totalNumberOfLinesInList > 1 && currentLineNumber == 1) {
             adjustment = if (this is AztecOrderedListSpan) 0 else verticalPadding

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -27,25 +27,32 @@ abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Stand
     }
 
     fun getNumberOfProcessedLine(text: CharSequence, end: Int): Int {
-        val textBeforeBeforeEnd = text.substring(0, end)
-        val lineIndex = textBeforeBeforeEnd.length - textBeforeBeforeEnd.replace("\n", "").length
-        return lineIndex + 1
-    }
-
-    fun getIndicatorAdjustment(text: CharSequence, end: Int): Int {
         val spanStart = (text as Spanned).getSpanStart(this)
         val spanEnd = text.getSpanEnd(this)
 
         val listText = text.subSequence(spanStart, spanEnd)
-        val lineNumber = getNumberOfProcessedLine(listText, end - spanStart)
 
+        val textBeforeBeforeEnd = listText.substring(0, end - spanStart)
+        val lineIndex = textBeforeBeforeEnd.length - textBeforeBeforeEnd.replace("\n", "").length
+        return lineIndex + 1
+    }
+
+    fun getTotalNumberOfLines(text: CharSequence): Int {
+        val spanStart = (text as Spanned).getSpanStart(this)
+        val spanEnd = text.getSpanEnd(this)
+
+        return text.substring(spanStart..spanEnd - 2).split("\n").count()
+    }
+
+    fun getIndicatorAdjustment(text: CharSequence, end: Int): Int {
         var adjustment = 0
 
-        val numberOfLines = text.substring(spanStart..spanEnd - 2).split("\n").count()
+        val totalNumberOfLinesInList = getTotalNumberOfLines(text)
+        val currentLineNumber = getNumberOfProcessedLine(text, end)
 
-        if (numberOfLines > 1 && lineNumber == 1) {
+        if (totalNumberOfLinesInList > 1 && currentLineNumber == 1) {
             adjustment = if (this is AztecOrderedListSpan) 0 else verticalPadding
-        } else if ((numberOfLines > 1 && numberOfLines == lineNumber) || numberOfLines == 1) {
+        } else if ((totalNumberOfLinesInList > 1 && totalNumberOfLinesInList == currentLineNumber) || totalNumberOfLinesInList == 1) {
             adjustment = -verticalPadding
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -1,6 +1,24 @@
 package org.wordpress.aztec.spans
 
+import android.os.Parcel
+import android.text.style.LeadingMarginSpan
+import org.wordpress.aztec.formatting.BlockFormatter
 
-interface AztecListSpan : AztecBlockSpan {
-    var lastItem: AztecListItemSpan
+
+abstract class AztecListSpan : LeadingMarginSpan.Standard, AztecBlockSpan {
+    abstract var lastItem: AztecListItemSpan
+
+    constructor(listStyle: BlockFormatter.ListStyle, attributes: String, last: AztecListItemSpan) : super(listStyle.indicatorMargin)
+
+    constructor(src: Parcel) : super(src)
+
+    constructor(attributes: String) : super(0)
+
+    constructor() : super(0)
+
+    fun getLineNumber(text: CharSequence, end: Int): Int {
+        val textBeforeBeforeEnd = text.substring(0, end)
+        val lineIndex = textBeforeBeforeEnd.length - textBeforeBeforeEnd.replace("\n", "").length
+        return lineIndex + 1
+    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -9,11 +9,12 @@ import android.text.style.UpdateLayout
 
 abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Standard(0), AztecBlockSpan, LineHeightSpan, UpdateLayout {
 
+    abstract var lastItem: AztecListItemSpan
+
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
         val spanned = text as Spanned
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
-
 
         if (start === spanStart || start < spanStart) {
             fm.ascent -= verticalPadding
@@ -25,21 +26,18 @@ abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Stand
         }
     }
 
-    abstract var lastItem: AztecListItemSpan
-
-    fun getLineNumber(text: CharSequence, end: Int): Int {
+    fun getNumberOfProcessedLine(text: CharSequence, end: Int): Int {
         val textBeforeBeforeEnd = text.substring(0, end)
         val lineIndex = textBeforeBeforeEnd.length - textBeforeBeforeEnd.replace("\n", "").length
         return lineIndex + 1
     }
 
-    fun getVerticalPadding(text: CharSequence, end: Int): Int {
+    fun getIndicatorAdjustment(text: CharSequence, end: Int): Int {
         val spanStart = (text as Spanned).getSpanStart(this)
         val spanEnd = text.getSpanEnd(this)
 
         val listText = text.subSequence(spanStart, spanEnd)
-
-        val lineNumber = getLineNumber(listText, end - spanStart)
+        val lineNumber = getNumberOfProcessedLine(listText, end - spanStart)
 
         var adjustment = 0
 
@@ -47,9 +45,7 @@ abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Stand
 
         if (numberOfLines > 1 && lineNumber == 1) {
             adjustment = if (this is AztecOrderedListSpan) 0 else verticalPadding
-        } else if (numberOfLines > 1 && numberOfLines == lineNumber) {
-            adjustment = -verticalPadding
-        } else if (numberOfLines == 1) {
+        } else if ((numberOfLines > 1 && numberOfLines == lineNumber) || numberOfLines == 1) {
             adjustment = -verticalPadding
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -9,8 +9,7 @@ import android.view.View
 import android.widget.Toast
 import org.wordpress.android.util.DisplayUtils
 
-class AztecMediaSpan(val context: Context, drawable: Drawable, source: String) : ImageSpan(drawable),
-        AztecParagraphStyle{
+class AztecMediaSpan(val context: Context, drawable: Drawable, source: String) : ImageSpan(drawable), AztecParagraphStyle{
     private val html = source
 
     companion object {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecMediaSpan.kt
@@ -5,13 +5,12 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.text.style.ImageSpan
-import android.text.style.ParagraphStyle
 import android.view.View
 import android.widget.Toast
-
 import org.wordpress.android.util.DisplayUtils
 
-class AztecMediaSpan(val context: Context, drawable: Drawable, source: String) : ImageSpan(drawable), ParagraphStyle {
+class AztecMediaSpan(val context: Context, drawable: Drawable, source: String) : ImageSpan(drawable),
+        AztecParagraphStyle{
     private val html = source
 
     companion object {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -83,7 +83,7 @@ class AztecOrderedListSpan : AztecListSpan {
         p.color = textColor
         p.style = Paint.Style.FILL
 
-        val textToDraw = getNumberOfProcessedLine(text, end).toString() + "."
+        val textToDraw = getIndexOfProcessedLine(text, end).toString() + "."
 
         val width = p.measureText(textToDraw)
         c.drawText(textToDraw, (textMargin + x + dir - width) * dir, (bottom - p.descent()) + getIndicatorAdjustment(text, end), p)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -77,7 +77,6 @@ class AztecOrderedListSpan : AztecListSpan {
 
         if (start !in spanStart..spanEnd || end !in spanStart..spanEnd) return
 
-
         val style = p.style
         val oldColor = p.color
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -41,18 +41,19 @@ class AztecOrderedListSpan : AztecListSpan, LineHeightSpan.WithDensity, UpdateLa
 
 
         if (start === spanStart || start < spanStart) {
-            fm.ascent -= 50
-            fm.top -= 50
+            fm.ascent -= verticalPadding
+            fm.top -= verticalPadding
         }
         if (end === spanEnd || spanEnd < end) {
-            fm.descent += 50
-            fm.bottom += 50
+            fm.descent += verticalPadding
+            fm.bottom += verticalPadding
         }
 
     }
 
     private val TAG = "ol"
 
+    private var verticalPadding: Int = 0
     private var textColor: Int = 0
     private var textMargin: Int = 0
     private var textPadding: Int = 0
@@ -61,28 +62,18 @@ class AztecOrderedListSpan : AztecListSpan, LineHeightSpan.WithDensity, UpdateLa
     override var attributes: String = ""
     override var lastItem: AztecListItemSpan = AztecListItemSpan()
 
-    //used for marking
-    constructor() : super() {
-    }
-
     constructor(attributes: String) : super() {
         this.attributes = attributes
     }
 
     constructor(listStyle: BlockFormatter.ListStyle, attributes: String, last: AztecListItemSpan) : super() {
+        this.verticalPadding = listStyle.verticalPadding
         this.textColor = listStyle.indicatorColor
         this.textMargin = listStyle.indicatorMargin
         this.bulletWidth = listStyle.indicatorWidth
         this.textPadding = listStyle.indicatorPadding
         this.attributes = attributes
         this.lastItem = last
-    }
-
-    constructor(src: Parcel) : super(src) {
-        this.textColor = src.readInt()
-        this.textMargin = src.readInt()
-        this.textPadding = src.readInt()
-        this.attributes = src.readString()
     }
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
@@ -132,9 +123,9 @@ class AztecOrderedListSpan : AztecListSpan, LineHeightSpan.WithDensity, UpdateLa
         if (numberOfLines > 1 && lineNumber == 1) {
             adjustment = 0
         } else if (numberOfLines > 1 && numberOfLines == lineNumber) {
-            adjustment = -50
+            adjustment = -verticalPadding
         } else if (numberOfLines == 1) {
-            adjustment = -50
+            adjustment = -verticalPadding
         }
 
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -84,10 +84,10 @@ class AztecOrderedListSpan : AztecListSpan {
         p.color = textColor
         p.style = Paint.Style.FILL
 
-        val textToDraw = getLineNumber(text, end).toString() + "."
+        val textToDraw = getNumberOfProcessedLine(text, end).toString() + "."
 
         val width = p.measureText(textToDraw)
-        c.drawText(textToDraw, (textMargin + x + dir - width) * dir, (bottom - p.descent()) + getVerticalPadding(text, end), p)
+        c.drawText(textToDraw, (textMargin + x + dir - width) * dir, (bottom - p.descent()) + getIndicatorAdjustment(text, end), p)
 
         p.color = oldColor
         p.style = style

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecParagraphStyle.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecParagraphStyle.kt
@@ -5,6 +5,6 @@ import android.text.style.ParagraphStyle
 /**
  * Marks spans that are going to be parsed with {@link org.wordpress.aztec.AztecParser#withinHtml()}
  * Created in order to distinguish between spans that implement ParagraphStyle for various reasons, but have separate
- * parsing logic.
+ * parsing logic, like  {@link org.wordpress.aztec.spans.AztecHeadingSpan}
  **/
 interface AztecParagraphStyle : ParagraphStyle

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecParagraphStyle.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecParagraphStyle.kt
@@ -1,0 +1,10 @@
+package org.wordpress.aztec.spans
+
+import android.text.style.ParagraphStyle
+
+/**
+ * Marks spans that are going to be parsed with {@link org.wordpress.aztec.AztecParser#withinHtml()}
+ * Created in order to distinguish between spans that implement ParagraphStyle for various reasons, but have separate
+ * parsing logic.
+ **/
+interface AztecParagraphStyle : ParagraphStyle

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -22,18 +22,45 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.os.Parcel
 import android.text.Layout
+import android.text.Spanned
+import android.text.TextPaint
 import android.text.TextUtils
 import android.text.style.LineBackgroundSpan
+import android.text.style.LineHeightSpan
 import android.text.style.QuoteSpan
+import android.text.style.UpdateLayout
 import org.wordpress.aztec.formatting.BlockFormatter
 
 
-class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan {
+class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeightSpan.WithDensity, UpdateLayout {
+
+
+    override fun chooseHeight(p0: CharSequence?, p1: Int, p2: Int, p3: Int, p4: Int, p5: Paint.FontMetricsInt?) {
+        throw UnsupportedOperationException("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt, paint: TextPaint) {
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        val spanEnd = spanned.getSpanEnd(this)
+
+
+        if (start === spanStart || start < spanStart) {
+            fm.ascent -= verticalPadding
+            fm.top -= verticalPadding
+        }
+        if (end === spanEnd || spanEnd < end) {
+            fm.descent += verticalPadding
+            fm.bottom += verticalPadding
+        }
+
+    }
 
     val rect = Rect()
 
     private val TAG: String = "blockquote"
 
+    private var verticalPadding: Int = 0
     private var quoteBackground: Int = 0
     private var quoteColor: Int = 0
     private var quoteMargin: Int = 0
@@ -48,6 +75,7 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan {
     }
 
     constructor(quoteStyle: BlockFormatter.QuoteStyle, attributes: String = "") : this(attributes) {
+        this.verticalPadding = quoteStyle.verticalPadding
         this.quoteBackground = quoteStyle.quoteBackground
         this.quoteColor = quoteStyle.quoteColor
         this.quoteMargin = quoteStyle.quoteMargin
@@ -87,10 +115,19 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan {
         return quoteMargin + quoteWidth + quotePadding
     }
 
+    fun getLineNumber(text: CharSequence, end: Int): Int {
+        val textBeforeBeforeEnd = text.substring(0, end)
+        val lineIndex = textBeforeBeforeEnd.length - textBeforeBeforeEnd.replace("\n", "").length
+        return lineIndex + 1
+    }
+
+
     override fun drawLeadingMargin(c: Canvas, p: Paint, x: Int, dir: Int,
                                    top: Int, baseline: Int, bottom: Int,
                                    text: CharSequence, start: Int, end: Int,
                                    first: Boolean, layout: Layout) {
+
+
         val style = p.style
         val color = p.color
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -20,10 +20,8 @@ package org.wordpress.aztec.spans
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
-import android.os.Parcel
 import android.text.Layout
 import android.text.Spanned
-import android.text.TextPaint
 import android.text.TextUtils
 import android.text.style.LineBackgroundSpan
 import android.text.style.LineHeightSpan
@@ -32,29 +30,7 @@ import android.text.style.UpdateLayout
 import org.wordpress.aztec.formatting.BlockFormatter
 
 
-class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeightSpan.WithDensity, UpdateLayout {
-
-
-    override fun chooseHeight(p0: CharSequence?, p1: Int, p2: Int, p3: Int, p4: Int, p5: Paint.FontMetricsInt?) {
-        throw UnsupportedOperationException("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt, paint: TextPaint) {
-        val spanned = text as Spanned
-        val spanStart = spanned.getSpanStart(this)
-        val spanEnd = spanned.getSpanEnd(this)
-
-
-        if (start === spanStart || start < spanStart) {
-            fm.ascent -= verticalPadding
-            fm.top -= verticalPadding
-        }
-        if (end === spanEnd || spanEnd < end) {
-            fm.descent += verticalPadding
-            fm.bottom += verticalPadding
-        }
-
-    }
+class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeightSpan, UpdateLayout {
 
     val rect = Rect()
 
@@ -83,21 +59,20 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeight
         this.quotePadding = quoteStyle.quotePadding
     }
 
-    constructor(src: Parcel) : super(src) {
-        this.quoteBackground = src.readInt()
-        this.quoteColor = src.readInt()
-        this.quoteMargin = src.readInt()
-        this.quoteWidth = src.readInt()
-        this.quotePadding = src.readInt()
-    }
+    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        val spanEnd = spanned.getSpanEnd(this)
 
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        super.writeToParcel(dest, flags)
-        dest.writeInt(quoteBackground)
-        dest.writeInt(quoteColor)
-        dest.writeInt(quoteMargin)
-        dest.writeInt(quoteWidth)
-        dest.writeInt(quotePadding)
+
+        if (start === spanStart || start < spanStart) {
+            fm.ascent -= verticalPadding
+            fm.top -= verticalPadding
+        }
+        if (end === spanEnd || spanEnd < end) {
+            fm.descent += verticalPadding
+            fm.bottom += verticalPadding
+        }
     }
 
     override fun getStartTag(): String {
@@ -115,19 +90,10 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeight
         return quoteMargin + quoteWidth + quotePadding
     }
 
-    fun getLineNumber(text: CharSequence, end: Int): Int {
-        val textBeforeBeforeEnd = text.substring(0, end)
-        val lineIndex = textBeforeBeforeEnd.length - textBeforeBeforeEnd.replace("\n", "").length
-        return lineIndex + 1
-    }
-
-
     override fun drawLeadingMargin(c: Canvas, p: Paint, x: Int, dir: Int,
                                    top: Int, baseline: Int, bottom: Int,
                                    text: CharSequence, start: Int, end: Int,
                                    first: Boolean, layout: Layout) {
-
-
         val style = p.style
         val color = p.color
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -64,7 +64,6 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeight
         val spanStart = spanned.getSpanStart(this)
         val spanEnd = spanned.getSpanEnd(this)
 
-
         if (start === spanStart || start < spanStart) {
             fm.ascent -= verticalPadding
             fm.top -= verticalPadding

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -22,11 +22,35 @@ import android.graphics.Paint
 import android.graphics.Path
 import android.os.Parcel
 import android.text.Layout
+import android.text.Spanned
+import android.text.TextPaint
 import android.text.TextUtils
-import android.text.style.BulletSpan
+import android.text.style.LineHeightSpan
+import android.text.style.UpdateLayout
 import org.wordpress.aztec.formatting.BlockFormatter
 
-class AztecUnorderedListSpan : BulletSpan, AztecListSpan {
+class AztecUnorderedListSpan : AztecListSpan, LineHeightSpan.WithDensity, UpdateLayout {
+
+    override fun chooseHeight(p0: CharSequence?, p1: Int, p2: Int, p3: Int, p4: Int, p5: Paint.FontMetricsInt?) {
+        throw UnsupportedOperationException("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt, paint: TextPaint) {
+        val spanned = text as Spanned
+        val spanStart = spanned.getSpanStart(this)
+        val spanEnd = spanned.getSpanEnd(this)
+
+
+        if (start === spanStart || start < spanStart) {
+            fm.ascent -= 50
+            fm.top -= 50
+        }
+        if (end === spanEnd || spanEnd < end) {
+            fm.descent += 50
+            fm.bottom += 50
+        }
+
+    }
 
     private val TAG = "ul"
 
@@ -40,7 +64,7 @@ class AztecUnorderedListSpan : BulletSpan, AztecListSpan {
     override var lastItem: AztecListItemSpan = AztecListItemSpan()
 
     //used for marking
-    constructor() : super(0) {
+    constructor() : super() {
     }
 
     constructor(attributes: String) {
@@ -101,19 +125,34 @@ class AztecUnorderedListSpan : BulletSpan, AztecListSpan {
         p.color = bulletColor
         p.style = Paint.Style.FILL
 
+        val spanStart = (text as Spanned).getSpanStart(this)
+        val spanEnd = text.getSpanEnd(this)
+
+        var adjustment = 0
+
+        val numberOfLines = text.substring(spanStart..spanEnd - 2).split("\n").count()
+
+        val listText = text.subSequence(spanStart, spanEnd)
+        val lineNumber = getLineNumber(listText, end - spanStart)
+
+        if (numberOfLines > 1 && lineNumber == 1) {
+            adjustment = 50
+        } else if (numberOfLines > 1 && numberOfLines == lineNumber) {
+            adjustment = -50
+        } else if (numberOfLines == 1) {
+            adjustment = -50
+        }
+
         if (c.isHardwareAccelerated) {
-            if (bulletPath == null) {
-                bulletPath = Path()
-                // Bullet is slightly better to avoid aliasing artifacts on mdpi devices.
-                bulletPath!!.addCircle(0.0f, 0.0f, bulletWidth.toFloat(), Path.Direction.CW)
-            }
+            bulletPath = Path()
+            bulletPath!!.addCircle(0.0f, 0.0f + adjustment / 2, bulletWidth.toFloat(), Path.Direction.CW)
 
             c.save()
-            c.translate((x + bulletMargin + dir * bulletWidth).toFloat(), (top + bottom) / 2.0f)
+            c.translate((x + bulletMargin + dir * bulletWidth).toFloat(), ((top + bottom) / 2.0f))
             c.drawPath(bulletPath!!, p)
             c.restore()
         } else {
-            c.drawCircle((x + bulletMargin + dir * bulletWidth).toFloat(), (top + bottom) / 2.0f, bulletWidth.toFloat(), p)
+            c.drawCircle((x + bulletMargin + dir * bulletWidth).toFloat(), ((top + bottom) / 2.0f) + adjustment / 2, bulletWidth.toFloat(), p)
         }
 
         p.color = oldColor

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -83,14 +83,14 @@ class AztecUnorderedListSpan : AztecListSpan {
 
         if (c.isHardwareAccelerated) {
             bulletPath = Path()
-            bulletPath!!.addCircle(0.0f, 0.0f + getVerticalPadding(text, end) / 2, bulletWidth.toFloat(), Path.Direction.CW)
+            bulletPath!!.addCircle(0.0f, 0.0f + getIndicatorAdjustment(text, end) / 2, bulletWidth.toFloat(), Path.Direction.CW)
 
             c.save()
             c.translate((x + bulletMargin + dir * bulletWidth).toFloat(), ((top + bottom) / 2.0f))
             c.drawPath(bulletPath!!, p)
             c.restore()
         } else {
-            c.drawCircle((x + bulletMargin + dir * bulletWidth).toFloat(), ((top + bottom) / 2.0f) + getVerticalPadding(text, end) / 2, bulletWidth.toFloat(), p)
+            c.drawCircle((x + bulletMargin + dir * bulletWidth).toFloat(), ((top + bottom) / 2.0f) + getIndicatorAdjustment(text, end) / 2, bulletWidth.toFloat(), p)
         }
 
         p.color = oldColor

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -42,18 +42,19 @@ class AztecUnorderedListSpan : AztecListSpan, LineHeightSpan.WithDensity, Update
 
 
         if (start === spanStart || start < spanStart) {
-            fm.ascent -= 50
-            fm.top -= 50
+            fm.ascent -= verticalPadding
+            fm.top -= verticalPadding
         }
         if (end === spanEnd || spanEnd < end) {
-            fm.descent += 50
-            fm.bottom += 50
+            fm.descent += verticalPadding
+            fm.bottom += verticalPadding
         }
 
     }
 
     private val TAG = "ul"
 
+    private var verticalPadding: Int = 0
     private var bulletColor: Int = 0
     private var bulletMargin: Int = 0
     private var bulletPadding: Int = 0
@@ -63,29 +64,19 @@ class AztecUnorderedListSpan : AztecListSpan, LineHeightSpan.WithDensity, Update
     override var attributes: String = ""
     override var lastItem: AztecListItemSpan = AztecListItemSpan()
 
-    //used for marking
-    constructor() : super() {
-    }
 
     constructor(attributes: String) {
         this.attributes = attributes
     }
 
     constructor(listStyle: BlockFormatter.ListStyle, attributes: String, last: AztecListItemSpan) {
+        this.verticalPadding = listStyle.verticalPadding
         this.bulletColor = listStyle.indicatorColor
         this.bulletMargin = listStyle.indicatorMargin
         this.bulletWidth = listStyle.indicatorWidth
         this.bulletPadding = listStyle.indicatorPadding
         this.attributes = attributes
         this.lastItem = last
-    }
-
-    constructor(src: Parcel) : super(src) {
-        this.bulletColor = src.readInt()
-        this.bulletMargin = src.readInt()
-        this.bulletWidth = src.readInt()
-        this.bulletPadding = src.readInt()
-        this.attributes = src.readString()
     }
 
     override fun getStartTag(): String {
@@ -136,11 +127,11 @@ class AztecUnorderedListSpan : AztecListSpan, LineHeightSpan.WithDensity, Update
         val lineNumber = getLineNumber(listText, end - spanStart)
 
         if (numberOfLines > 1 && lineNumber == 1) {
-            adjustment = 50
+            adjustment = verticalPadding
         } else if (numberOfLines > 1 && numberOfLines == lineNumber) {
-            adjustment = -50
+            adjustment = -verticalPadding
         } else if (numberOfLines == 1) {
-            adjustment = -50
+            adjustment = -verticalPadding
         }
 
         if (c.isHardwareAccelerated) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
@@ -2,11 +2,11 @@ package org.wordpress.aztec.spans
 
 import android.content.Context
 import android.text.style.ImageSpan
-import android.text.style.ParagraphStyle
 import android.view.View
 import android.widget.Toast
 
-class UnknownHtmlSpan(rawHtml: StringBuilder, context: Context, drawable: Int) : ImageSpan(context, drawable), ParagraphStyle {
+class UnknownHtmlSpan(rawHtml: StringBuilder, context: Context, drawable: Int) : ImageSpan(context, drawable),
+        AztecParagraphStyle{
 
     val mRawHtml: StringBuilder = rawHtml
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/UnknownHtmlSpan.kt
@@ -5,12 +5,11 @@ import android.text.style.ImageSpan
 import android.view.View
 import android.widget.Toast
 
-class UnknownHtmlSpan(rawHtml: StringBuilder, context: Context, drawable: Int) : ImageSpan(context, drawable),
-        AztecParagraphStyle{
+class UnknownHtmlSpan(rawHtml: StringBuilder, context: Context, drawable: Int) : ImageSpan(context, drawable), AztecParagraphStyle {
 
     val mRawHtml: StringBuilder = rawHtml
 
-    fun getRawHtml() : StringBuilder {
+    fun getRawHtml(): StringBuilder {
         return mRawHtml
     }
 

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
         <attr name="bulletMargin" format="reference|dimension" />
         <attr name="bulletPadding" format="reference|dimension" />
         <attr name="bulletWidth" format="reference|dimension" />
+        <attr name="blockVerticalPadding" format="reference|dimension" />
         <attr name="historyEnable" format="reference|boolean" />
         <attr name="historySize" format="reference|integer" />
         <attr name="lineSpacingExtra" format="reference|dimension" />

--- a/aztec/src/main/res/values/dimens.xml
+++ b/aztec/src/main/res/values/dimens.xml
@@ -9,7 +9,7 @@
     <dimen name="quote_padding">8dp</dimen>
     <dimen name="quote_margin">16dp</dimen>
     <dimen name="quote_width">2dp</dimen>
-    <dimen name="block_element_vertical_padding">8dp</dimen>
+    <dimen name="block_vertical_padding">8dp</dimen>
     <dimen name="spacing_extra">16dp</dimen>
     <item type="dimen" format="string" name="spacing_multiplier">1.0</item>
 

--- a/aztec/src/main/res/values/dimens.xml
+++ b/aztec/src/main/res/values/dimens.xml
@@ -9,6 +9,7 @@
     <dimen name="quote_padding">8dp</dimen>
     <dimen name="quote_margin">16dp</dimen>
     <dimen name="quote_width">2dp</dimen>
+    <dimen name="block_element_vertical_padding">8dp</dimen>
     <dimen name="spacing_extra">16dp</dimen>
     <item type="dimen" format="string" name="spacing_multiplier">1.0</item>
 

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -37,6 +37,7 @@
         <item name="quoteMargin">@dimen/quote_margin</item>
         <item name="quotePadding">@dimen/quote_padding</item>
         <item name="quoteWidth">@dimen/quote_width</item>
+        <item name="blockVerticalPadding">@dimen/block_element_vertical_padding</item>
         <item name="codeBackground">@color/code_background</item>
         <item name="codeColor">@color/code</item>
         <item name="textColor">@android:color/white</item>

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -37,7 +37,7 @@
         <item name="quoteMargin">@dimen/quote_margin</item>
         <item name="quotePadding">@dimen/quote_padding</item>
         <item name="quoteWidth">@dimen/quote_width</item>
-        <item name="blockVerticalPadding">@dimen/block_element_vertical_padding</item>
+        <item name="blockVerticalPadding">@dimen/block_vertical_padding</item>
         <item name="codeBackground">@color/code_background</item>
         <item name="codeColor">@color/code</item>
         <item name="textColor">@android:color/white</item>


### PR DESCRIPTION
### Fixes #162 

Adds more vertical padding (+8dp) to block elements and headings.

The only approach that proven to work was using LineHeightSpan, but the drawback to it is that cursor height is also affected. With moderate padding it's not so noticeable, but maybe it's something we should address in the future. 

![padding](https://cloud.githubusercontent.com/assets/728822/22587951/0c791ed8-ea47-11e6-9d7f-8b568e845365.png)
