### PR TITLE
Issue/225 allow images in block elements

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -51,7 +51,7 @@ abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Stand
         val currentLineNumber = getIndexOfProcessedLine(text, end)
 
         if (totalNumberOfLinesInList > 1 && currentLineNumber == 1) {
-            adjustment = if (this is AztecOrderedListSpan) 0 else verticalPadding
+            adjustment = 0
         } else if ((totalNumberOfLinesInList > 1 && totalNumberOfLinesInList == currentLineNumber) || totalNumberOfLinesInList == 1) {
             adjustment = -verticalPadding
         }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -19,7 +19,6 @@ package org.wordpress.aztec.spans
 
 import android.graphics.Canvas
 import android.graphics.Paint
-import android.graphics.Path
 import android.text.Layout
 import android.text.Spanned
 import android.text.TextUtils
@@ -64,7 +63,6 @@ class AztecUnorderedListSpan : AztecListSpan {
     }
 
 
-
     override fun getLeadingMargin(first: Boolean): Int {
         return bulletMargin + 2 * bulletWidth + bulletPadding
     }
@@ -86,24 +84,14 @@ class AztecUnorderedListSpan : AztecListSpan {
         p.color = bulletColor
         p.style = Paint.Style.FILL
 
-        if (c.isHardwareAccelerated) {
-            bulletPath = Path()
-            bulletPath!!.addCircle(0.0f, 0.0f + getIndicatorAdjustment(text, end) / 2, bulletWidth.toFloat(), Path.Direction.CW)
+        val textToDraw = "\u2022"
 
-            c.save()
-            c.translate((x + bulletMargin + dir * bulletWidth).toFloat(), ((top + bottom) / 2.0f))
-            c.drawPath(bulletPath!!, p)
-            c.restore()
-        } else {
-            c.drawCircle((x + bulletMargin + dir * bulletWidth).toFloat(), ((top + bottom) / 2.0f) + getIndicatorAdjustment(text, end) / 2, bulletWidth.toFloat(), p)
-        }
+        val width = p.measureText(textToDraw)
+        c.drawText(textToDraw, (bulletMargin + x + dir - width) * dir, (bottom - p.descent()) - width / 2 + getIndicatorAdjustment(text, end), p)
 
         p.color = oldColor
         p.style = style
 
     }
 
-    companion object {
-        private var bulletPath: Path? = null
-    }
 }


### PR DESCRIPTION
### Fixes #225

Inserting images does not break block elements anymore.
Also, Instead of splitting them, like before, we are inserting images inside them instead.

In addition, Images are now allowed inside headings.

PS: I noticed rare visual rendering issues - heigh of line might fluctuate when images are inserted.