### PR TITLE
Issue/220 fix highlighting of shared styles

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -174,6 +174,7 @@ class AztecText : EditText, TextWatcher {
             var consumeKeyEvent = false
             history.beforeTextChanged(toFormattedHtml())
             if (keyCode == KeyEvent.KEYCODE_DEL && event.action == KeyEvent.ACTION_DOWN) {
+                inlineFormatter.tryRemoveLeadingInlineStyle()
                 consumeKeyEvent = blockFormatter.tryRemoveBlockStyleFromFirstLine()
             }
 
@@ -514,8 +515,8 @@ class AztecText : EditText, TextWatcher {
         }
 
         val newLine = textChangedEventDetails.isNewLine()
-        blockFormatter.handleBlockStyling(text, textChangedEventDetails)
         inlineFormatter.handleInlineStyling(textChangedEventDetails)
+        blockFormatter.handleBlockStyling(text, textChangedEventDetails)
         lineBlockFormatter.handleLineBlockStyling(textChangedEventDetails)
 
         isMediaAdded = text.getSpans(0, text.length, AztecMediaSpan::class.java).isNotEmpty()
@@ -876,6 +877,8 @@ class AztecText : EditText, TextWatcher {
         override fun sendKeyEvent(event: KeyEvent): Boolean {
             if (event.action === KeyEvent.ACTION_DOWN && event.keyCode === KeyEvent.KEYCODE_DEL) {
                 history.beforeTextChanged(toFormattedHtml())
+
+                inlineFormatter.tryRemoveLeadingInlineStyle()
                 val isStyleRemoved = blockFormatter.tryRemoveBlockStyleFromFirstLine()
                 if (isStyleRemoved) {
                     history.handleHistory(this@AztecText)
@@ -981,7 +984,8 @@ class AztecText : EditText, TextWatcher {
                         return@filter attributePredicate.matches(it.attributes as Attributes)
                     } else {
                         return@filter false
-                    }}
+                    }
+                }
                 .map { it.attributes }
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -245,6 +245,14 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                 text.setSpan(blockSpan, text.getSpanStart(blockSpan), end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             }
         }
+
+        //remove inline styles from the ZWJ characters we inserted
+        var indexOfZWJ = editableText.indexOf(Constants.ZWJ_CHAR)
+        while (indexOfZWJ >= 0) {
+            editor.removeInlineStylesFromRange(indexOfZWJ, indexOfZWJ + 1)
+            indexOfZWJ = editableText.indexOf(Constants.ZWJ_CHAR, indexOfZWJ + 1)
+        }
+
     }
 
     fun removeBlockStyle(textFormat: TextFormat) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -548,11 +548,13 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                 val spans = editableText.getSpans(textChangedEvent.inputStart, textChangedEvent.inputStart, AztecLineBlockSpan::class.java)
 
                 spans.forEach {
-                    val previousCharacter =
-                            if (textChangedEvent.isAddingCharacters) editableText[textChangedEvent.inputStart - 1]
-                            else editableText[textChangedEvent.inputEnd]
+                    if (textChangedEvent.inputStart > 0) {
+                        val previousCharacter =
+                                if (textChangedEvent.isAddingCharacters) editableText[textChangedEvent.inputStart - 1]
+                                else editableText[textChangedEvent.inputEnd]
 
-                    if (previousCharacter == '\n') return@forEach
+                        if (previousCharacter == '\n') return@forEach
+                    }
 
                     val deletingLastCharacter = !textChangedEvent.isAddingCharacters && editableText.length == textChangedEvent.inputEnd
                     if (deletingLastCharacter) return@forEach

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -409,4 +409,17 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, val headerSty
             return originalText.isNotEmpty() && originalText == textOfCombinedSpans
         }
     }
+
+    fun tryRemoveLeadingInlineStyle() {
+        val selectionStart = editor.selectionStart
+        val selectionEnd = editor.selectionEnd
+
+        if (selectionStart == 1 && selectionEnd == selectionStart) {
+            editableText.getSpans(0, 0, AztecInlineSpan::class.java).forEach {
+                if (editableText.getSpanEnd(it) == selectionEnd && editableText.getSpanEnd(it) == selectionStart) {
+                    editableText.removeSpan(it)
+                }
+            }
+        }
+    }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -403,7 +403,10 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, val headerSty
                 }
             }
 
-            return editableText.subSequence(start, end).toString() == builder.toString()
+            val originalText = editableText.subSequence(start, end).replace("\n".toRegex(), "")
+            val textOfCombinedSpans = builder.toString().replace("\n".toRegex(), "")
+
+            return originalText.isNotEmpty() && originalText == textOfCombinedSpans
         }
     }
 }


### PR DESCRIPTION
### Fixes #220 and #231

To test: 

#220
1. Load demo app with couple of inline styles each on new line, like BOLD + ITALIC + UNDERLINE +STRIKETHROUGH
2. Select each individual line and apply style, Bold, for example.
3.  Select all the lines and confirm that Bold is highlighted in toolbar.

#231
1. Make a list or quote.
2. Press enter to add new line to it.
3. Press Bold style in toolbar and start typing.
4. Notice that bold style is properly applied.
