### PR TITLE
Only click the Clickable span if inside it

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -202,6 +202,8 @@ class MainActivity : AppCompatActivity(), OnRequestPermissionsResultCallback, Vi
         aztec.imageGetter = PicassoImageLoader(this, aztec)
 //        aztec.imageGetter = GlideImageLoader(this)
 
+        aztec.setOnMediaTappedListener(this)
+
         source = findViewById(R.id.source) as SourceViewEditText
 
         formattingToolbar = findViewById(R.id.formatting_toolbar) as AztecToolbar
@@ -218,8 +220,6 @@ class MainActivity : AppCompatActivity(), OnRequestPermissionsResultCallback, Vi
         aztec.setOnTouchListener(this)
         source.setOnImeBackListener(this)
         source.setOnTouchListener(this)
-
-        aztec.setOnMediaTappedListener(this)
     }
 
     override fun onPause() {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -1,9 +1,11 @@
 package org.wordpress.aztec
 
+import android.graphics.Rect
 import android.text.Selection
 import android.text.Spannable
 import android.text.method.ArrowKeyMovementMethod
 import android.text.style.ClickableSpan
+import android.util.Log
 import android.view.MotionEvent
 import android.widget.TextView
 import org.wordpress.aztec.spans.AztecMediaClickableSpan
@@ -30,17 +32,25 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val line = layout.getLineForVertical(y)
             val off = layout.getOffsetForHorizontal(line, x.toFloat())
 
-            val link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull()
+            val charRight = layout.getPrimaryHorizontal(off)
+            val charLeft = layout.getPrimaryHorizontal(off - 1)
 
-            // Only react to AztecMediaClickableSpan and UnknownClickableSpan; not to regular links.
-            if (link != null && (link is AztecMediaClickableSpan || link is UnknownClickableSpan)) {
-                if (action == MotionEvent.ACTION_UP) {
-                    link.onClick(widget)
-                } else {
-                    Selection.setSelection(text, text.getSpanStart(link), text.getSpanEnd(link))
+            val lineRect = Rect()
+            layout.getLineBounds(line, lineRect)
+
+            if (x >= charLeft && x <= charRight && y >= lineRect.top && y <= lineRect.bottom) {
+                val link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull()
+
+                // Only react to AztecMediaClickableSpan and UnknownClickableSpan; not to regular links.
+                if (link != null && (link is AztecMediaClickableSpan || link is UnknownClickableSpan)) {
+                    if (action == MotionEvent.ACTION_UP) {
+                        link.onClick(widget)
+                    } else {
+                        Selection.setSelection(text, text.getSpanStart(link), text.getSpanEnd(link))
+                    }
+
+                    return true
                 }
-
-                return true
             }
         }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/EnhancedMovementMethod.kt
@@ -32,13 +32,17 @@ object EnhancedMovementMethod : ArrowKeyMovementMethod() {
             val line = layout.getLineForVertical(y)
             val off = layout.getOffsetForHorizontal(line, x.toFloat())
 
-            val charRight = layout.getPrimaryHorizontal(off)
-            val charLeft = layout.getPrimaryHorizontal(off - 1)
+            // get the character's position. This may be the left or the right edge of the character so, find the
+            //  other edge by inspecting nearby characters (if they exist)
+            val charX = layout.getPrimaryHorizontal(off)
+            val charPrevX = if (off > 0) layout.getPrimaryHorizontal(off - 1) else charX
+            val charNextX = if (off < text.length) layout.getPrimaryHorizontal(off + 1) else charX
 
             val lineRect = Rect()
             layout.getLineBounds(line, lineRect)
 
-            if (x >= charLeft && x <= charRight && y >= lineRect.top && y <= lineRect.bottom) {
+            if (((x >= charPrevX && x <= charX) || (x >= charX && x <= charNextX))
+                    && y >= lineRect.top && y <= lineRect.bottom) {
                 val link = text.getSpans(off, off, ClickableSpan::class.java).firstOrNull()
 
                 // Only react to AztecMediaClickableSpan and UnknownClickableSpan; not to regular links.


### PR DESCRIPTION
### Fix #229 

Restrict the triggering of ClickableSpan's click method to only happen if the tap happened inside its range.

Note: the implementation is accurate for the horizontal detection of the span's range but not the vertical.

### Test
1. Using the demo app, tap _around_ an image
2. The cursor should move without triggering the "media tapped" event (i.e. the "Media tapped!" toast won't show)
