### PR TITLE
Issue/fix visual glicthes with block elements

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -137,6 +137,8 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                     spanEnd += textChangedEvent.count
                 } else if (indexOfLineEnd == -1) {
                     spanEnd = text.length
+                } else {
+                    spanEnd = indexOfLineEnd
                 }
 
                 if (spanEnd <= textLength) {
@@ -231,7 +233,7 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
             }
         } else if (!textChangedEvent.isAddingCharacters && !textChangedEvent.isNewLineButNotAtTheBeginning()) {
             val deletedCharacterIsNewline = textChangedEvent.textBefore[textChangedEvent.inputEnd] == '\n'
-            if(!deletedCharacterIsNewline) return
+            if (!deletedCharacterIsNewline) return
 
             // backspace on a line right after a list attaches the line to the last item
             val blockSpan = editableText.getSpans(inputEnd, inputEnd, AztecBlockSpan::class.java).firstOrNull()

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -123,14 +123,20 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                         spanEnd,
                         Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             } else if (textChangedEvent.isAddingCharacters) {
+
+                val spanEndsWithNewline = editableText.indexOf('\n', textChangedEvent.inputStart, true) == spanEnd - textChangedEvent.numberOfAddedCharacters
+
+                //if span we are inserting text into is ending with newline we don't need to extend it
+                if (spanEndsWithNewline) {
+                    return@forEach
+                }
+
                 val indexOfLineEnd = text.indexOf('\n', spanEnd - 1, true)
 
                 if (indexOfLineEnd == spanEnd) {
                     spanEnd += textChangedEvent.count
                 } else if (indexOfLineEnd == -1) {
                     spanEnd = text.length
-                } else {
-                    spanEnd = indexOfLineEnd
                 }
 
                 if (spanEnd <= textLength) {
@@ -224,6 +230,9 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                 }
             }
         } else if (!textChangedEvent.isAddingCharacters && !textChangedEvent.isNewLineButNotAtTheBeginning()) {
+            val deletedCharacterIsNewline = textChangedEvent.textBefore[textChangedEvent.inputEnd] == '\n'
+            if(!deletedCharacterIsNewline) return
+
             // backspace on a line right after a list attaches the line to the last item
             val blockSpan = editableText.getSpans(inputEnd, inputEnd, AztecBlockSpan::class.java).firstOrNull()
             val before = Math.min(inputStart, inputEnd)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -138,7 +138,7 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                 } else if (indexOfLineEnd == -1) {
                     spanEnd = text.length
                 } else {
-                    spanEnd = indexOfLineEnd
+                    spanEnd = indexOfLineEnd + if (textChangedEvent.isAfterZeroWidthJoiner()) 1 else 0
                 }
 
                 if (spanEnd <= textLength) {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecListSpan.kt
@@ -37,26 +37,4 @@ abstract class AztecListSpan(val verticalPadding: Int) : LeadingMarginSpan.Stand
         return lineIndex + 1
     }
 
-    fun getTotalNumberOfLines(text: CharSequence): Int {
-        val spanStart = (text as Spanned).getSpanStart(this)
-        val spanEnd = text.getSpanEnd(this)
-
-        return text.substring(spanStart..spanEnd - 2).split("\n").count()
-    }
-
-    fun getIndicatorAdjustment(text: CharSequence, end: Int): Int {
-        var adjustment = 0
-
-        val totalNumberOfLinesInList = getTotalNumberOfLines(text)
-        val currentLineNumber = getIndexOfProcessedLine(text, end)
-
-        if (totalNumberOfLinesInList > 1 && currentLineNumber == 1) {
-            adjustment = 0
-        } else if ((totalNumberOfLinesInList > 1 && totalNumberOfLinesInList == currentLineNumber) || totalNumberOfLinesInList == 1) {
-            adjustment = -verticalPadding
-        }
-
-        return adjustment
-    }
-
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -86,7 +86,7 @@ class AztecOrderedListSpan : AztecListSpan {
         val textToDraw = getIndexOfProcessedLine(text, end).toString() + "."
 
         val width = p.measureText(textToDraw)
-        c.drawText(textToDraw, (textMargin + x + dir - width) * dir, (bottom - p.descent()) + getIndicatorAdjustment(text, end), p)
+        c.drawText(textToDraw, (textMargin + x + dir - width) * dir, (baseline + width + p.ascent()), p)
 
         p.color = oldColor
         p.style = style

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecOrderedListSpan.kt
@@ -86,7 +86,7 @@ class AztecOrderedListSpan : AztecListSpan {
         val textToDraw = getIndexOfProcessedLine(text, end).toString() + "."
 
         val width = p.measureText(textToDraw)
-        c.drawText(textToDraw, (textMargin + x + dir - width) * dir, (baseline + width + p.ascent()), p)
+        c.drawText(textToDraw, (textMargin + x + dir - width) * dir, baseline.toFloat(), p)
 
         p.color = oldColor
         p.style = style

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecUnorderedListSpan.kt
@@ -87,7 +87,7 @@ class AztecUnorderedListSpan : AztecListSpan {
         val textToDraw = "\u2022"
 
         val width = p.measureText(textToDraw)
-        c.drawText(textToDraw, (bulletMargin + x + dir - width) * dir, (bottom - p.descent()) - width / 2 + getIndicatorAdjustment(text, end), p)
+        c.drawText(textToDraw, (bulletMargin + x + dir - width) * dir, (baseline + (width - p.descent())), p)
 
         p.color = oldColor
         p.style = style


### PR DESCRIPTION
This PR addresses visual glitches when adding/removing characters.

I was able to fix all of them except for one - when you have a line of plain text above block element, add/remove character from that line, and the line with block element moves up/down a bit.

Same as @0nko , I traced this down to DynamicLayout reflow method, and this happens because we are using `LineHeightSpan` decorated with `UpdateLayout` interface for block element paddings.

At this point I don't know how to fix it, except for coming with other way of implementing paddings. But the issue is minor, so I think we could address it a bit later, when more critical issues are fixed.

In addition, I changed the drawing logic of lists indicator, to base them on `baseline` value, instead of `bottom` value, which makes more sense, and does not requires any adjustment's that come from variable line height.

