### PR TITLE
Issue/219 code highlight color

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -131,6 +131,7 @@ class AztecText : EditText, TextWatcher {
         inlineFormatter = InlineFormatter(this,
                 InlineFormatter.CodeStyle(
                         array.getColor(R.styleable.AztecText_codeBackground, 0),
+                        array.getFraction(R.styleable.AztecText_codeBackgroundAlpha, 1, 1, 0f),
                         array.getColor(R.styleable.AztecText_codeColor, 0)),
                 LineBlockFormatter.HeaderStyle(
                         array.getDimensionPixelSize(R.styleable.AztecText_blockVerticalPadding, 0)))

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -14,7 +14,7 @@ import java.util.*
 class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, val headerStyle: LineBlockFormatter.HeaderStyle) : AztecFormatter(editor) {
 
     data class CarryOverSpan(val span: AztecInlineSpan, val start: Int, val end: Int)
-    data class CodeStyle(val codeBackground: Int, val codeColor: Int)
+    data class CodeStyle(val codeBackground: Int, val codeBackgroundAlpha: Float, val codeColor: Int)
 
     val carryOverSpans = ArrayList<CarryOverSpan>()
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecCodeSpan.kt
@@ -17,6 +17,7 @@
 
 package org.wordpress.aztec.spans
 
+import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Parcel
 import android.text.ParcelableSpan
@@ -30,6 +31,7 @@ class AztecCodeSpan : MetricAffectingSpan, ParcelableSpan, AztecContentSpan, Azt
     private val TAG: String = "code"
 
     private var codeBackground: Int = 0
+    private var codeBackgroundAlpha: Float = 0.0f
     private var codeColor: Int = 0
 
     override var attributes: String = ""
@@ -40,11 +42,13 @@ class AztecCodeSpan : MetricAffectingSpan, ParcelableSpan, AztecContentSpan, Azt
 
     constructor(codeStyle: InlineFormatter.CodeStyle, attributes: String = "") : this(attributes) {
         this.codeBackground = codeStyle.codeBackground
+        this.codeBackgroundAlpha = codeStyle.codeBackgroundAlpha
         this.codeColor = codeStyle.codeColor
     }
 
     constructor(src: Parcel) {
         this.codeBackground = src.readInt()
+        this.codeBackgroundAlpha = src.readFloat()
         this.codeColor = src.readInt()
     }
 
@@ -85,8 +89,9 @@ class AztecCodeSpan : MetricAffectingSpan, ParcelableSpan, AztecContentSpan, Azt
     }
 
     private fun configureTextPaint(tp: TextPaint?) {
+        val alpha: Int = (codeBackgroundAlpha * 255).toInt()
         tp?.typeface = Typeface.MONOSPACE
-        tp?.bgColor = codeBackground
+        tp?.bgColor = Color.argb(alpha, Color.red(codeBackground), Color.green(codeBackground), Color.blue(codeBackground))
         tp?.color = codeColor
     }
 }

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -4,11 +4,14 @@
 
     <declare-styleable name="AztecText">
         <attr name="backgroundColor" format="reference|color" />
+        <attr name="blockVerticalPadding" format="reference|dimension" />
         <attr name="bulletColor" format="reference|color" />
         <attr name="bulletMargin" format="reference|dimension" />
         <attr name="bulletPadding" format="reference|dimension" />
         <attr name="bulletWidth" format="reference|dimension" />
-        <attr name="blockVerticalPadding" format="reference|dimension" />
+        <attr name="codeBackground" format="reference|color" />
+        <attr name="codeBackgroundAlpha" format="reference|fraction" />
+        <attr name="codeColor" format="reference|color" />
         <attr name="historyEnable" format="reference|boolean" />
         <attr name="historySize" format="reference|integer" />
         <attr name="lineSpacingExtra" format="reference|dimension" />
@@ -22,15 +25,13 @@
         <attr name="quoteWidth" format="reference|dimension" />
         <attr name="textColor" format="reference|color" />
         <attr name="textColorHint" format="reference|color" />
-        <attr name="codeBackground" format="reference|color" />
-        <attr name="codeBackgroundAlpha" format="reference|fraction" />
-        <attr name="codeColor" format="reference|color" />
     </declare-styleable>
 
     <declare-styleable name="SourceViewEditText">
-        <attr name="codeTextColor" format="reference|color" />
-        <attr name="codeBackgroundColor" format="reference|color" />
-        <attr name="tagColor" format="reference|color" />
         <attr name="attributeColor" format="reference|color" />
+        <attr name="codeBackgroundColor" format="reference|color" />
+        <attr name="codeTextColor" format="reference|color" />
+        <attr name="tagColor" format="reference|color" />
     </declare-styleable>
+
 </resources>

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -23,9 +23,10 @@
         <attr name="textColor" format="reference|color" />
         <attr name="textColorHint" format="reference|color" />
         <attr name="codeBackground" format="reference|color" />
+        <attr name="codeBackgroundAlpha" format="reference|fraction" />
         <attr name="codeColor" format="reference|color" />
     </declare-styleable>
-    
+
     <declare-styleable name="SourceViewEditText">
         <attr name="codeTextColor" format="reference|color" />
         <attr name="codeBackgroundColor" format="reference|color" />

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -39,6 +39,7 @@
         <item name="quoteWidth">@dimen/quote_width</item>
         <item name="blockVerticalPadding">@dimen/block_vertical_padding</item>
         <item name="codeBackground">@color/code_background</item>
+        <item name="codeBackgroundAlpha">75%</item>
         <item name="codeColor">@color/code</item>
         <item name="textColor">@android:color/white</item>
         <item name="textColorHint">@android:color/darker_gray</item>

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -24,10 +24,14 @@
     <style name="AztecTextStyle">
         <item name="android:textCursorDrawable">?attr/textColor</item>
         <item name="backgroundColor">@android:color/transparent</item>
+        <item name="blockVerticalPadding">@dimen/block_vertical_padding</item>
         <item name="bulletColor">@color/blue_medium</item>
         <item name="bulletMargin">@dimen/bullet_margin</item>
         <item name="bulletPadding">@dimen/bullet_padding</item>
         <item name="bulletWidth">@dimen/bullet_width</item>
+        <item name="codeBackground">@color/code_background</item>
+        <item name="codeBackgroundAlpha">75%</item>
+        <item name="codeColor">@color/code</item>
         <item name="lineSpacingExtra">@dimen/spacing_extra</item>
         <item name="lineSpacingMultiplier">@dimen/spacing_multiplier</item>
         <item name="linkColor">@color/blue_wordpress</item>
@@ -37,10 +41,6 @@
         <item name="quoteMargin">@dimen/quote_margin</item>
         <item name="quotePadding">@dimen/quote_padding</item>
         <item name="quoteWidth">@dimen/quote_width</item>
-        <item name="blockVerticalPadding">@dimen/block_vertical_padding</item>
-        <item name="codeBackground">@color/code_background</item>
-        <item name="codeBackgroundAlpha">75%</item>
-        <item name="codeColor">@color/code</item>
         <item name="textColor">@android:color/white</item>
         <item name="textColorHint">@android:color/darker_gray</item>
     </style>


### PR DESCRIPTION
### Fix
The highlight color in code styled text is shown as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/219 by modifying the new `codeBackgroundAlpha` attribute.  The demonstration app uses 75% opacity.

### Test
1. Open demonstration app.
2. Long-press on code block example text.
3. Notice text is highlighted.
4. Add `aztec:codeBackgroundAlpha` to [`AztecText`](https://github.com/wordpress-mobile/WordPress-Aztec-Android/blob/develop/app/src/main/res/layout/activity_main.xml#L26) with custom percentage.
5. Notice code block background alpha.
6. Long-press on code block example text.
7. Notice text is highlighted.