### PR TITLE
Fixin visibility of cursor in quote

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -146,6 +146,7 @@ class AztecText : EditText, TextWatcher {
                 BlockFormatter.QuoteStyle(
                         array.getColor(R.styleable.AztecText_quoteBackground, 0),
                         array.getColor(R.styleable.AztecText_quoteColor, 0),
+                        array.getFraction(R.styleable.AztecText_quoteBackgroundAlpha, 1, 1, 0f),
                         array.getDimensionPixelSize(R.styleable.AztecText_quoteMargin, 0),
                         array.getDimensionPixelSize(R.styleable.AztecText_quotePadding, 0),
                         array.getDimensionPixelSize(R.styleable.AztecText_quoteWidth, 0),

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -14,7 +14,7 @@ import java.util.*
 class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteStyle) : AztecFormatter(editor) {
 
     data class ListStyle(val indicatorColor: Int, val indicatorMargin: Int, val indicatorPadding: Int, val indicatorWidth: Int, val verticalPadding: Int)
-    data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
+    data class QuoteStyle(val quoteBackground: Int, val quoteColor: Int, val quoteBackgroundAlpha: Float, val quoteMargin: Int, val quotePadding: Int, val quoteWidth: Int, val verticalPadding: Int)
 
     val listStyle: ListStyle
     val quoteStyle: QuoteStyle

--- a/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/spans/AztecQuoteSpan.kt
@@ -18,6 +18,7 @@
 package org.wordpress.aztec.spans
 
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Rect
 import android.text.Layout
@@ -42,6 +43,7 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeight
     private var quoteMargin: Int = 0
     private var quotePadding: Int = 0
     private var quoteWidth: Int = 0
+    private var quoteBackgroundAlpha: Float = 0.0f
 
     override var attributes: String = ""
 
@@ -57,6 +59,7 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeight
         this.quoteMargin = quoteStyle.quoteMargin
         this.quoteWidth = quoteStyle.quoteWidth
         this.quotePadding = quoteStyle.quotePadding
+        this.quoteBackgroundAlpha = quoteStyle.quoteBackgroundAlpha
     }
 
     override fun chooseHeight(text: CharSequence, start: Int, end: Int, spanstartv: Int, v: Int, fm: Paint.FontMetricsInt) {
@@ -108,9 +111,10 @@ class AztecQuoteSpan : QuoteSpan, LineBackgroundSpan, AztecBlockSpan, LineHeight
                                 top: Int, baseline: Int, bottom: Int,
                                 text: CharSequence?, start: Int, end: Int,
                                 lnum: Int) {
-        val paintColor = p.color
-        p.color = quoteBackground
+        val alpha: Int = (quoteBackgroundAlpha * 255).toInt()
 
+        val paintColor = p.color
+        p.color = Color.argb(alpha, Color.red(quoteBackground), Color.green(quoteBackground), Color.blue(quoteBackground))
         rect.set(left + quoteMargin, top, right, bottom)
 
         c.drawRect(rect, p)

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
         <attr name="linkUnderline" format="reference|boolean" />
         <attr name="quoteBackground" format="reference|color" />
         <attr name="quoteColor" format="reference|color" />
+        <attr name="quoteBackgroundAlpha" format="reference|fraction" />
         <attr name="quoteMargin" format="reference|dimension" />
         <attr name="quotePadding" format="reference|dimension" />
         <attr name="quoteWidth" format="reference|dimension" />

--- a/aztec/src/main/res/values/styles.xml
+++ b/aztec/src/main/res/values/styles.xml
@@ -38,6 +38,7 @@
         <item name="linkUnderline">false</item>
         <item name="quoteBackground">@color/blue_wordpress</item>
         <item name="quoteColor">@color/blue_medium</item>
+        <item name="quoteBackgroundAlpha">75%</item>
         <item name="quoteMargin">@dimen/quote_margin</item>
         <item name="quotePadding">@dimen/quote_padding</item>
         <item name="quoteWidth">@dimen/quote_width</item>


### PR DESCRIPTION
Similar to @theck13 's PR (#244) adds an alpha channel to quote background color, to make cursor visible.