### PR TITLE
Issue/235 enable disable actions

### DIFF
--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -27,6 +27,7 @@ import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.PermissionUtils
 import org.wordpress.android.util.ToastUtils
 import org.wordpress.aztec.AztecText
+import org.wordpress.aztec.HistoryListener
 import org.wordpress.aztec.picassoloader.PicassoImageLoader
 import org.wordpress.aztec.source.SourceViewEditText
 import org.wordpress.aztec.toolbar.AztecToolbar
@@ -35,9 +36,14 @@ import org.xml.sax.Attributes
 import org.xml.sax.helpers.AttributesImpl
 import java.io.File
 
-class MainActivity : AppCompatActivity(), OnRequestPermissionsResultCallback, View.OnTouchListener,
-        PopupMenu.OnMenuItemClickListener, AztecToolbarClickListener, AztecText.OnMediaTappedListener,
-        AztecText.OnImeBackListener {
+class MainActivity : AppCompatActivity(),
+        AztecText.OnImeBackListener,
+        AztecText.OnMediaTappedListener,
+        AztecToolbarClickListener,
+        HistoryListener,
+        OnRequestPermissionsResultCallback,
+        PopupMenu.OnMenuItemClickListener,
+        View.OnTouchListener {
     companion object {
         private val HEADING =
                 "<h1>Heading 1</h1>" +
@@ -114,6 +120,8 @@ class MainActivity : AppCompatActivity(), OnRequestPermissionsResultCallback, Vi
     private var mediaUploadDialog: AlertDialog? = null
     private var mediaMenu: PopupMenu? = null
 
+    private var isRedoEnabled = false
+    private var isUndoEnabled = false
     private var mIsKeyboardOpen = false
     private var mHideActionBarOnSoftKeyboardUp = false
 
@@ -216,6 +224,7 @@ class MainActivity : AppCompatActivity(), OnRequestPermissionsResultCallback, Vi
 
         source.history = aztec.history
 
+        aztec.history.setHistoryListener(this)
         aztec.setOnImeBackListener(this)
         aztec.setOnTouchListener(this)
         source.setOnImeBackListener(this)
@@ -365,6 +374,22 @@ class MainActivity : AppCompatActivity(), OnRequestPermissionsResultCallback, Vi
         }
 
         return true
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+        menu?.findItem(R.id.redo)?.isEnabled = isRedoEnabled
+        menu?.findItem(R.id.undo)?.isEnabled = isUndoEnabled
+        return super.onPrepareOptionsMenu(menu)
+    }
+
+    override fun onRedoEnabled(state: Boolean) {
+        isRedoEnabled = state
+        invalidateOptionsMenu()
+    }
+
+    override fun onUndoEnabled(state: Boolean) {
+        isUndoEnabled = state
+        invalidateOptionsMenu()
     }
 
     fun onCameraPhotoMediaOptionSelected() {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -115,6 +115,9 @@ class MainActivity : AppCompatActivity(),
     private lateinit var source: SourceViewEditText
     private lateinit var formattingToolbar: AztecToolbar
 
+    private lateinit var invalidateOptionsHandler: Handler
+    private lateinit var invalidateOptionsRunnable: Runnable
+
     private var addPhotoMediaDialog: AlertDialog? = null
     private var addVideoMediaDialog: AlertDialog? = null
     private var mediaUploadDialog: AlertDialog? = null
@@ -227,6 +230,9 @@ class MainActivity : AppCompatActivity(),
         aztec.setOnTouchListener(this)
         source.setOnImeBackListener(this)
         source.setOnTouchListener(this)
+
+        invalidateOptionsHandler = Handler()
+        invalidateOptionsRunnable = Runnable { invalidateOptionsMenu() }
     }
 
     override fun onPause() {
@@ -381,11 +387,13 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun onRedoEnabled() {
-        invalidateOptionsMenu()
+        invalidateOptionsHandler.removeCallbacks(invalidateOptionsRunnable)
+        invalidateOptionsHandler.postDelayed(invalidateOptionsRunnable, resources.getInteger(android.R.integer.config_mediumAnimTime).toLong())
     }
 
     override fun onUndoEnabled() {
-        invalidateOptionsMenu()
+        invalidateOptionsHandler.removeCallbacks(invalidateOptionsRunnable)
+        invalidateOptionsHandler.postDelayed(invalidateOptionsRunnable, resources.getInteger(android.R.integer.config_mediumAnimTime).toLong())
     }
 
     fun onCameraPhotoMediaOptionSelected() {

--- a/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
+++ b/app/src/main/kotlin/org/wordpress/aztec/demo/MainActivity.kt
@@ -120,8 +120,6 @@ class MainActivity : AppCompatActivity(),
     private var mediaUploadDialog: AlertDialog? = null
     private var mediaMenu: PopupMenu? = null
 
-    private var isRedoEnabled = false
-    private var isUndoEnabled = false
     private var mIsKeyboardOpen = false
     private var mHideActionBarOnSoftKeyboardUp = false
 
@@ -377,18 +375,16 @@ class MainActivity : AppCompatActivity(),
     }
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        menu?.findItem(R.id.redo)?.isEnabled = isRedoEnabled
-        menu?.findItem(R.id.undo)?.isEnabled = isUndoEnabled
+        menu?.findItem(R.id.redo)?.isEnabled = aztec.history.redoValid()
+        menu?.findItem(R.id.undo)?.isEnabled = aztec.history.undoValid()
         return super.onPrepareOptionsMenu(menu)
     }
 
-    override fun onRedoEnabled(state: Boolean) {
-        isRedoEnabled = state
+    override fun onRedoEnabled() {
         invalidateOptionsMenu()
     }
 
-    override fun onUndoEnabled(state: Boolean) {
-        isUndoEnabled = state
+    override fun onUndoEnabled() {
         invalidateOptionsMenu()
     }
 

--- a/app/src/main/res/drawable/ic_action_redo_selector.xml
+++ b/app/src/main/res/drawable/ic_action_redo_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_action_redo_white_30_24dp" android:state_enabled="false" />
+    <item android:drawable="@drawable/ic_action_redo_white_24dp" />
+
+</selector>

--- a/app/src/main/res/drawable/ic_action_redo_white_30_24dp.xml
+++ b/app/src/main/res/drawable/ic_action_redo_white_30_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="#4dffffff"
+        android:pathData="M18.4,10.6C16.55,8.99 14.15,8 11.5,8c-4.65,0 -8.58,3.03 -9.96,7.22L3.9,16c1.05,-3.19 4.05,-5.5 7.6,-5.5 1.95,0 3.73,0.72 5.12,1.88L13,16h9V7l-3.6,3.6z" >
+    </path>
+
+</vector>

--- a/app/src/main/res/drawable/ic_action_undo_selector.xml
+++ b/app/src/main/res/drawable/ic_action_undo_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_action_undo_white_30_24dp" android:state_enabled="false" />
+    <item android:drawable="@drawable/ic_action_undo_white_24dp" />
+
+</selector>

--- a/app/src/main/res/drawable/ic_action_undo_white_30_24dp.xml
+++ b/app/src/main/res/drawable/ic_action_undo_white_30_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="#4dffffff"
+        android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z" >
+    </path>
+
+</vector>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -7,7 +7,7 @@
 
     <item
         android:id="@+id/undo"
-        android:icon="@drawable/ic_action_undo_white_24dp"
+        android:icon="@drawable/ic_action_undo_selector"
         android:title="@string/menu_undo"
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction" >
@@ -15,7 +15,7 @@
 
     <item
         android:id="@+id/redo"
-        android:icon="@drawable/ic_action_redo_white_24dp"
+        android:icon="@drawable/ic_action_redo_selector"
         android:title="@string/menu_redo"
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction" >

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -121,7 +121,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
             return false
         }
 
-        return historyCursor < historyList.size - 1 || historyCursor >= historyList.size - 1
+        return historyCursor < historyList.size
     }
 
     fun undoValid(): Boolean {

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -9,6 +9,8 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
     var historyList = LinkedList<String>()
     var inputLast: String = ""
 
+    private var historyListener: HistoryListener? = null
+
     private var historyWorking = false
 
     private lateinit var inputBefore: String
@@ -46,6 +48,8 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
 
         historyList.add(inputBefore)
         historyCursor = historyList.size
+
+        updateActions()
     }
 
     fun redo(editText: EditText) {
@@ -77,6 +81,8 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
         editText.isFocusable = true
         editText.isFocusableInTouchMode = true
         editText.requestFocus()
+
+        updateActions()
     }
 
     fun undo(editText: EditText) {
@@ -98,6 +104,8 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
         editText.isFocusable = true
         editText.isFocusableInTouchMode = true
         editText.requestFocus()
+
+        updateActions()
     }
 
     private fun setTextFromHistory(editText: EditText) {
@@ -131,5 +139,14 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
     fun clearHistory() {
         inputLast = ""
         historyList.clear()
+    }
+
+    fun setHistoryListener(listener: HistoryListener) {
+        historyListener = listener
+    }
+
+    fun updateActions() {
+        historyListener?.onRedoEnabled(redoValid())
+        historyListener?.onUndoEnabled(undoValid())
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/History.kt
@@ -146,7 +146,7 @@ class History(val historyEnabled: Boolean, val historySize: Int) {
     }
 
     fun updateActions() {
-        historyListener?.onRedoEnabled(redoValid())
-        historyListener?.onUndoEnabled(undoValid())
+        historyListener?.onRedoEnabled()
+        historyListener?.onUndoEnabled()
     }
 }

--- a/aztec/src/main/kotlin/org/wordpress/aztec/HistoryListener.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/HistoryListener.kt
@@ -1,0 +1,6 @@
+package org.wordpress.aztec
+
+interface HistoryListener {
+    fun onRedoEnabled(state: Boolean)
+    fun onUndoEnabled(state: Boolean)
+}

--- a/aztec/src/main/kotlin/org/wordpress/aztec/HistoryListener.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/HistoryListener.kt
@@ -1,6 +1,6 @@
 package org.wordpress.aztec
 
 interface HistoryListener {
-    fun onRedoEnabled(state: Boolean)
-    fun onUndoEnabled(state: Boolean)
+    fun onRedoEnabled()
+    fun onUndoEnabled()
 }


### PR DESCRIPTION
### Fix
Update the state of the redo and undo actions as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/235.

### Test
1. Open demonstration app.
2. Notice ***Redo*** is disabled and ***Undo*** are disabled.
3. Type one character.
4. Notice ***Redo*** is disabled and ***Undo*** is enabled.
5. Type nine or more characters.
6. Notice ***Redo*** is disabled and ***Undo*** is enabled.
7. Tap ***Undo*** action button one time.
8. Notice ***Redo*** is enabled and ***Undo*** is enabled.
9. Tap ***Undo*** action button nine times.
10. Notice ***Redo*** is enabled and ***Undo*** is disabled.
11. Tap ***Redo*** action button one time.
12. Notice ***Redo*** is enabled and ***Undo*** is enabled.
13. Tap ***Redo*** action button nine times.
14. Notice ***Redo*** is disabled and ***Undo*** is enabled.