### PR TITLE
Issue/250 fix broken links on older api

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -189,6 +189,17 @@ class AztecText : EditText, TextWatcher {
         isViewInitialized = true
     }
 
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        val selStart = selectionStart
+        val selEnd = selectionEnd
+
+        super.onWindowFocusChanged(hasWindowFocus)
+        if (!hasWindowFocus) {
+            //on older android versions selection is lost when window loses focus, so we are making sure to keep it
+            setSelection(selStart, selEnd)
+        }
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         addTextChangedListener(this)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -232,7 +232,8 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
                 }
             }
         } else if (!textChangedEvent.isAddingCharacters && !textChangedEvent.isNewLineButNotAtTheBeginning()) {
-            val deletedCharacterIsNewline = textChangedEvent.textBefore[textChangedEvent.inputEnd] == '\n'
+            val deletedCharacterIsNewline = textChangedEvent.textBefore.length > textChangedEvent.inputEnd &&
+                    textChangedEvent.textBefore[textChangedEvent.inputEnd] == '\n'
             if (!deletedCharacterIsNewline) return
 
             // backspace on a line right after a list attaches the line to the last item


### PR DESCRIPTION
### Fix #250 

On older android devices selection is lost when window loses focus (when you open ADD LINK or MEDIA dialog).

This PR preserves selection when window loses focus. 
Also ads a length check when accessing previous editor content text in block formatter.  

To test:

Select some text.
Open ADD LINK dialog.
Add link.
Confirm that the selected text is properly replaced with anchor.
