### PR TITLE
Issue/maintain toolbar state

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -1,6 +1,8 @@
 package org.wordpress.aztec.toolbar
 
 import android.content.Context
+import android.os.Bundle
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.MenuItem
 import android.view.View
@@ -71,6 +73,22 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
             }
             else -> return false
         }
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        val savedState = state as SourceViewEditText.SavedState
+        super.onRestoreInstanceState(savedState.superState)
+        val restoredState = savedState.state
+        toggleHtmlMode(restoredState.getBoolean("isSourceVisible"))
+    }
+
+    override fun onSaveInstanceState(): Parcelable {
+        val superState = super.onSaveInstanceState()
+        val savedState = SourceViewEditText.SavedState(superState)
+        val bundle = Bundle()
+        bundle.putBoolean("isSourceVisible", sourceEditor?.visibility == View.VISIBLE)
+        savedState.state = bundle
+        return savedState
     }
 
     private fun isEditorAttached(): Boolean {


### PR DESCRIPTION
### Fix
Save and restore toolbar state (i.e enabled or disabled) when rotating the device.

### Test
1. Open demonstration app.
2. Notice toolbar is enabled.
3. Rotate device.
4. Notice toolbar is enabled.
5. Tap ***HTML*** format button.
6. Notice toolbar is disabled.
7. Rotate device.
8. Notice toolbar is disabled.