### PR TITLE
Issue/265 fixing link issue

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt
@@ -428,7 +428,8 @@ class AztecText : EditText, TextWatcher, UnknownHtmlSpan.OnUnknownHtmlClickListe
     }
 
     fun getSelectedText(): String {
-        if (selectionStart == -1 || selectionEnd == -1) return ""
+        if (selectionStart == -1 || selectionEnd == -1
+                || editableText.length < selectionEnd || editableText.length < selectionStart) return ""
         return editableText.substring(selectionStart, selectionEnd)
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -279,7 +279,6 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
             val spanStart = editableText.getSpanStart(it)
             var spanEnd = editableText.getSpanEnd(it)
 
-
             //when removing empty span don't forget to delete ZWJ
             if(spanEnd - spanStart == 1 && editableText[spanStart] == Constants.ZWJ_CHAR){
                 editableText.removeSpan(it)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -279,6 +279,15 @@ class BlockFormatter(editor: AztecText, listStyle: ListStyle, quoteStyle: QuoteS
             val spanStart = editableText.getSpanStart(it)
             var spanEnd = editableText.getSpanEnd(it)
 
+
+            //when removing empty span don't forget to delete ZWJ
+            if(spanEnd - spanStart == 1 && editableText[spanStart] == Constants.ZWJ_CHAR){
+                editableText.removeSpan(it)
+                editor.disableTextChangedListener()
+                editableText.delete(spanStart, spanStart + 1)
+                return@forEach
+            }
+
             //if splitting block set a range that would be excluded from it
             val boundsOfSelectedText = if (ignoreLineBounds) IntRange(start, end) else getSelectedTextBounds(editableText, start, end)
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/LinkTest.kt
@@ -63,6 +63,25 @@ class LinkTest() {
         Assert.assertEquals("<a href=\"http://wordpress.com\">WordPress</a>", editText.toHtml())
     }
 
+    @Test
+    @Throws(Exception::class)
+    fun insertLinkIntoEmptyQuote() {
+        editText.toggleFormatting(TextFormat.FORMAT_QUOTE)
+        Assert.assertEquals("<blockquote></blockquote>", editText.toHtml())
+        editText.setSelection(editText.length())
+        editText.link("http://wordpress.com", "WordPress")
+        Assert.assertEquals("<blockquote><a href=\"http://wordpress.com\">WordPress</a></blockquote>", editText.toHtml())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun insertLinkIntoEmptyList() {
+        editText.toggleFormatting(TextFormat.FORMAT_ORDERED_LIST)
+        Assert.assertEquals("<ol><li></li></ol>", editText.toHtml())
+        editText.setSelection(editText.length())
+        editText.link("http://wordpress.com", "WordPress")
+        Assert.assertEquals("<ol><li><a href=\"http://wordpress.com\">WordPress</a></li></ol>", editText.toHtml())
+    }
 
     @Test
     @Throws(Exception::class)

--- a/aztec/src/test/kotlin/org/wordpress/aztec/ListTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/ListTest.kt
@@ -110,6 +110,11 @@ class ListTest(listTextFormat: TextFormat, listHtmlTag: String) {
     fun emptyList() {
         editText.toggleFormatting(listType)
         Assert.assertEquals("<$listTag><li></li></$listTag>", editText.toHtml())
+
+        //remove list
+        editText.toggleFormatting(listType)
+        Assert.assertEquals(0, editText.length())
+        Assert.assertEquals("", editText.toHtml())
     }
 
     @Test

--- a/aztec/src/test/kotlin/org/wordpress/aztec/QuoteTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/QuoteTest.kt
@@ -94,6 +94,11 @@ class QuoteTest() {
     fun emptyQuote() {
         editText.toggleFormatting(formattingType)
         Assert.assertEquals("<$quoteTag></$quoteTag>", editText.toHtml())
+
+        //remove quote
+        editText.toggleFormatting(formattingType)
+        Assert.assertEquals(0, editText.length())
+        Assert.assertEquals("", editText.toHtml())
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #271 and #265

I wasn't able to reproduce #265, so I just added a safeguard agains OOB exception.

Regarding #271 problem was with lingering ZWJ character - when we add link into empty block quote the ZWJ gets consumed, and this messes up with indexes. 