### PR TITLE
Issue/260 span tag space

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -18,7 +18,7 @@ object Format {
         html = replaceAll(html, iframePlaceholder, "iframe")
 
         //remove newline around all non block elements
-        val newlineToTheLeft = replaceAll(html, "(?<!</?($block)>)\n\\s*?<((?!/?($block)).*?)>", "<$2>")
+        val newlineToTheLeft = replaceAll(html, "(?<!</?($block)>)\\s*?<((?!/?($block)).*?)>", "<$2>")
         val newlineToTheRight = replaceAll(newlineToTheLeft, "<(/?(?!$block).)>\n(?!</?($block)>)", "<$1>")
         var fixBrNewlines = replaceAll(newlineToTheRight, "([\t ]*)(<br>)(?!\n)", "$1$2\n$1")
         fixBrNewlines = replaceAll(fixBrNewlines, ">([\t ]*)(<br>)", ">\n$1$2")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -18,7 +18,7 @@ object Format {
         html = replaceAll(html, iframePlaceholder, "iframe")
 
         //remove newline around all non block elements
-        val newlineToTheLeft = replaceAll(html, "(?<!</?($block)>)\\s*?<((?!/?($block)).*?)>", "<$2>")
+        val newlineToTheLeft = replaceAll(html, "(?<!</?($block)>)\n<((?!/?($block)).*?)>", "<$2>")
         val newlineToTheRight = replaceAll(newlineToTheLeft, "<(/?(?!$block).)>\n(?!</?($block)>)", "<$1>")
         var fixBrNewlines = replaceAll(newlineToTheRight, "([\t ]*)(<br>)(?!\n)", "$1$2\n$1")
         fixBrNewlines = replaceAll(fixBrNewlines, ">([\t ]*)(<br>)", ">\n$1$2")

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/Format.kt
@@ -1,20 +1,13 @@
 package org.wordpress.aztec.source
 
-import android.support.v4.util.ArrayMap
-import org.apache.commons.lang.StringEscapeUtils
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
 import java.util.regex.Pattern
-import org.jsoup.nodes.Entities.EscapeMode
-import org.jsoup.safety.Cleaner
-import org.jsoup.safety.Whitelist
-
 
 
 object Format {
 
     // list of block elements
-    private val block = "div|span|br|blockquote|ul|ol|li|p|h1|h2|h3|h4|h5|h6|iframe"
+    private val block = "div|br|blockquote|ul|ol|li|p|h1|h2|h3|h4|h5|h6|iframe"
 
     private val iframePlaceholder = "iframe-replacement-0x0"
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -69,6 +69,9 @@ class HtmlFormattingTest() : AndroidTestCase() {
                     "</div>" +
                     "<br>"
 
+    private val HTML_BLOCK_WITH_NEWLINES = "\n\n<div>Division</div>\n\n"
+    private val HTML_BLOCK_WITHOUT_NEWLINES = "<div>Division</div>"
+
     /**
      * Initialize variables.
      */
@@ -117,5 +120,19 @@ class HtmlFormattingTest() : AndroidTestCase() {
         val span = SpannableString(parser.fromHtml(input, null, null, context))
         val output = Format.clearFormatting(Format.addFormatting(parser.toHtml(span)))
         Assert.assertEquals(HTML_MIXED_NO_WS, output)
+    }
+
+    /**
+     * Test block conversion from HTML to visual mode with newlines.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Throws(Exception::class)
+    fun formatNewlines() {
+        val input = HTML_BLOCK_WITH_NEWLINES
+        val span = SpannableString(parser.fromHtml(input, null, null, context))
+        val output = Format.clearFormatting(Format.addFormatting(parser.toHtml(span)))
+        Assert.assertEquals(HTML_BLOCK_WITHOUT_NEWLINES, output)
     }
 }

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -13,10 +13,9 @@ import org.wordpress.aztec.source.Format
 
 @RunWith(RobolectricTestRunner::class)
 @Config(constants = BuildConfig::class, sdk = intArrayOf(23))
-class HtmlFormattingTest() : AndroidTestCase() {
+class HtmlFormattingTest : AndroidTestCase() {
 
     private var parser = AztecParser()
-
 
     private val HTML_LINE_BREAKS = "HI<br><br><br><br><br><br>BYE"
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -35,7 +35,7 @@ class HtmlFormattingTest() : AndroidTestCase() {
             "</div>" +
             "<br><br>"
 
-    private val HTML_MIXED =
+    private val HTML_MIXED_WITH_NEWLINES =
             "\n\n<span><i>Italic</i></span>\n\n" +
             "<b>Bold</b><br>" +
             "\t<div class=\"first\">" +
@@ -52,7 +52,7 @@ class HtmlFormattingTest() : AndroidTestCase() {
             "</div>" +
             "<br>"
 
-    private val HTML_MIXED_NO_WS =
+    private val HTML_MIXED_WITHOUT_NEWLINES =
             "<span><i>Italic</i></span>" +
                     " <b>Bold</b><br>" +
                     "<div class=\"first\">" +
@@ -116,10 +116,10 @@ class HtmlFormattingTest() : AndroidTestCase() {
     @Test
     @Throws(Exception::class)
     fun formatMixedHtml() {
-        val input = HTML_MIXED
+        val input = HTML_MIXED_WITH_NEWLINES
         val span = SpannableString(parser.fromHtml(input, null, null, context))
         val output = Format.clearFormatting(Format.addFormatting(parser.toHtml(span)))
-        Assert.assertEquals(HTML_MIXED_NO_WS, output)
+        Assert.assertEquals(HTML_MIXED_WITHOUT_NEWLINES, output)
     }
 
     /**

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -30,7 +30,7 @@ class HtmlFormattingTest : AndroidTestCase() {
             "<div class=\"fifth\"></div>" +
             "</div>" +
             "<span class=\"second last\"></span>" +
-            "<span></span><div><div><div><span></span></div></div></div><div></div>" +
+            "<div><span></span><div><div><span></span></div></div></div><div></div>" +
             "</div>" +
             "<br><br>"
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HtmlFormattingTest.kt
@@ -54,7 +54,7 @@ class HtmlFormattingTest() : AndroidTestCase() {
 
     private val HTML_MIXED_NO_WS =
             "<span><i>Italic</i></span>" +
-                    "<b>Bold</b><br>" +
+                    " <b>Bold</b><br>" +
                     "<div class=\"first\">" +
                     "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\">Link</a>" +
                     "<div class=\"second\">" +


### PR DESCRIPTION
### Fix
Maintain space around `span` tags as described in https://github.com/wordpress-mobile/WordPress-Aztec-Android/issues/260.  Since the [`span` tag is an inline element](https://www.w3schools.com/html/html_blocks.asp), it was removed from the block formatting list resulting in the HTML format shown in the screenshots below (i.e. Block is before the change and Inline is after).

![span](https://cloud.githubusercontent.com/assets/3827611/23322598/f43a902a-faa1-11e6-976f-85b951821861.png)

### Test
1. Tap ***HTML*** format button.
2. Enter `span` tag with whitespace and text surrounding it.
3. Tap ***HTML*** format button.
4. Notice whitespace remains around `span` tag.