### PR TITLE
Fix #255: make sure we can't add a null textFormat to the action list

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -316,7 +316,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
             val actions = getSelectedActions()
             val textFormats = ArrayList<TextFormat>()
 
-            actions.forEach { if (it.isStylingAction()) textFormats.add(it.textFormat!!) }
+            actions.forEach { if (it.isStylingAction() && it.textFormat != null) textFormats.add(it.textFormat) }
             if (getSelectedHeading() != null) {
                 textFormats.add(getSelectedHeading()!!)
             }


### PR DESCRIPTION
Fix #255: make sure we can't add a null textFormat to the action list

I wasn't able to reproduce on an emulator, but this happens sometimes when I tap the bold button on my phone. I _think_ both the `HEADING` and `BOLD` actions are triggered at the same time and since the `textFormat` field of `HEADING` is null, it was crashing. The fix makes sure `textFormat` is not null when adding it to the aciton list.