### PR TITLE
issue/toolbar-media-mode

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/toolbar/AztecToolbar.kt
@@ -26,6 +26,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
     private var headingMenu: PopupMenu? = null
     private var sourceEditor: SourceViewEditText? = null
     private var dialogShortcuts: AlertDialog? = null
+    private var isMediaModeEnabled: Boolean = false;
 
     constructor(context: Context) : super(context) {
         initView()
@@ -228,6 +229,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         super.onRestoreInstanceState(savedState.superState)
         val restoredState = savedState.state
         toggleHtmlMode(restoredState.getBoolean("isSourceVisible"))
+        enableMediaMode(restoredState.getBoolean("isMediaMode"))
     }
 
     override fun onSaveInstanceState(): Parcelable {
@@ -235,6 +237,7 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         val savedState = SourceViewEditText.SavedState(superState)
         val bundle = Bundle()
         bundle.putBoolean("isSourceVisible", sourceEditor?.visibility == View.VISIBLE)
+        bundle.putBoolean("isMediaMode", isMediaModeEnabled)
         savedState.state = bundle
         return savedState
     }
@@ -404,6 +407,21 @@ class AztecToolbar : FrameLayout, OnMenuItemClickListener {
         ToolbarAction.values().forEach { action ->
             if (action != ToolbarAction.HTML) {
                 toggleButtonState(findViewById(action.buttonId), isEnabled)
+            }
+        }
+    }
+
+    fun isMediaModeEnabled(): Boolean {
+        return isMediaModeEnabled;
+    }
+
+    fun enableMediaMode(isEnabled: Boolean) {
+        isMediaModeEnabled = isEnabled;
+        ToolbarAction.values().forEach { action ->
+            if (action == ToolbarAction.ADD_MEDIA) {
+                toggleButton(findViewById(action.buttonId), isEnabled)
+            } else {
+                toggleButtonState(findViewById(action.buttonId), !isEnabled)
             }
         }
     }

--- a/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
@@ -4,9 +4,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/format_bar_button_media_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_checked="true" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_focused="true" />
-    <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_checked="true" />
     <item android:drawable="@drawable/format_bar_button_media" />
 
 </selector>

--- a/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
+++ b/aztec/src/main/res/drawable/format_bar_button_media_selector.xml
@@ -6,6 +6,7 @@
     <item android:drawable="@drawable/format_bar_button_media_disabled" android:state_enabled="false" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_pressed="true" />
     <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_focused="true" />
+    <item android:drawable="@drawable/format_bar_button_media_highlighted" android:state_checked="true" />
     <item android:drawable="@drawable/format_bar_button_media" />
 
 </selector>


### PR DESCRIPTION
Adds "media mode" to the toolbar which will be used with the new photo chooser in WP Android. This highlights the media button and disables all the others.