### PR TITLE
Issue/source dialog style

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -47,10 +47,12 @@ class SourceViewEditText : EditText, TextWatcher {
 
     private fun init(attrs: AttributeSet?) {
         val values = context.obtainStyledAttributes(attrs, R.styleable.SourceViewEditText)
-        if (values.hasValue(R.styleable.SourceViewEditText_codeBackgroundColor)) {
-            setBackgroundColor(values.getColor(R.styleable.SourceViewEditText_codeBackgroundColor, ContextCompat.getColor(context, R.color.background)))
+
+        setBackgroundColor(values.getColor(R.styleable.SourceViewEditText_codeBackgroundColor, ContextCompat.getColor(context, android.R.color.transparent)))
+
+        if (!values.hasValue(R.styleable.SourceViewEditText_codeDialog)) {
+            setTextColor(values.getColor(R.styleable.SourceViewEditText_codeTextColor, android.R.attr.textColorPrimary))
         }
-        setTextColor(values.getColor(R.styleable.SourceViewEditText_codeTextColor, ContextCompat.getColor(context, R.color.text)))
 
         tagColor = values.getColor(R.styleable.SourceViewEditText_tagColor, tagColor)
         attributeColor = values.getColor(R.styleable.SourceViewEditText_attributeColor, attributeColor)

--- a/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/source/SourceViewEditText.kt
@@ -50,7 +50,7 @@ class SourceViewEditText : EditText, TextWatcher {
 
         setBackgroundColor(values.getColor(R.styleable.SourceViewEditText_codeBackgroundColor, ContextCompat.getColor(context, android.R.color.transparent)))
 
-        if (!values.hasValue(R.styleable.SourceViewEditText_codeDialog)) {
+        if (!values.hasValue(R.styleable.SourceViewEditText_codeDialog) && values.getBoolean(R.styleable.SourceViewEditText_codeDialog, false)) {
             setTextColor(values.getColor(R.styleable.SourceViewEditText_codeTextColor, android.R.attr.textColorPrimary))
         }
 

--- a/aztec/src/main/res/layout/dialog_block_editor.xml
+++ b/aztec/src/main/res/layout/dialog_block_editor.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<org.wordpress.aztec.source.SourceViewEditText
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aztec="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/source"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:gravity="top|start"
-    android:inputType="textNoSuggestions|textMultiLine"
-    android:layout_marginLeft="24dp"
-    android:layout_marginRight="24dp"
-    android:layout_marginStart="24dp"
-    android:layout_marginEnd="24dp"
-    android:layout_marginTop="24dp"
-    android:padding="16dp"
-    android:scrollbars="vertical"
-    android:scrollbarStyle="outsideOverlay"
-    android:textSize="14sp"
-    android:imeOptions="flagNoExtractUi"
-    aztec:codeDialog="true" >
-</org.wordpress.aztec.source.SourceViewEditText>
+    android:layout_height="match_parent"
+    android:layout_width="match_parent" >
+
+    <org.wordpress.aztec.source.SourceViewEditText
+        xmlns:aztec="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/source"
+        android:gravity="top|start"
+        android:imeOptions="flagNoExtractUi"
+        android:inputType="textNoSuggestions|textMultiLine"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:padding="@dimen/margin_large"
+        android:scrollbars="vertical"
+        android:scrollbarStyle="outsideOverlay"
+        android:textSize="@dimen/text_dialog"
+        aztec:codeDialog="true" >
+    </org.wordpress.aztec.source.SourceViewEditText>
+
+</ScrollView>

--- a/aztec/src/main/res/layout/dialog_block_editor.xml
+++ b/aztec/src/main/res/layout/dialog_block_editor.xml
@@ -1,30 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"-->
-    <!--xmlns:aztec="http://schemas.android.com/apk/res-auto"-->
-    <!--android:orientation="vertical"-->
-    <!--android:layout_width="match_parent"-->
-    <!--android:layout_height="match_parent"-->
-    <!--android:fillViewport="true">-->
 
-    <org.wordpress.aztec.source.SourceViewEditText
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:aztec="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/source"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="top|start"
-        android:inputType="textNoSuggestions|textMultiLine"
-        android:layout_marginLeft="24dp"
-        android:layout_marginRight="24dp"
-        android:layout_marginStart="24dp"
-        android:layout_marginEnd="24dp"
-        android:layout_marginTop="24dp"
-        android:padding="16dp"
-        android:scrollbars="vertical"
-        android:scrollbarStyle="outsideOverlay"
-        android:textSize="14sp"
-        android:imeOptions="flagNoExtractUi"
-        aztec:codeDialog="true" >
-    </org.wordpress.aztec.source.SourceViewEditText>
-
-<!--</ScrollView>-->
+<org.wordpress.aztec.source.SourceViewEditText
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aztec="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/source"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="top|start"
+    android:inputType="textNoSuggestions|textMultiLine"
+    android:layout_marginLeft="24dp"
+    android:layout_marginRight="24dp"
+    android:layout_marginStart="24dp"
+    android:layout_marginEnd="24dp"
+    android:layout_marginTop="24dp"
+    android:padding="16dp"
+    android:scrollbars="vertical"
+    android:scrollbarStyle="outsideOverlay"
+    android:textSize="14sp"
+    android:imeOptions="flagNoExtractUi"
+    aztec:codeDialog="true" >
+</org.wordpress.aztec.source.SourceViewEditText>

--- a/aztec/src/main/res/layout/dialog_block_editor.xml
+++ b/aztec/src/main/res/layout/dialog_block_editor.xml
@@ -21,10 +21,10 @@
         android:layout_marginTop="24dp"
         android:padding="16dp"
         android:scrollbars="vertical"
-        android:background="@drawable/background_block_editor"
         android:scrollbarStyle="outsideOverlay"
         android:textSize="14sp"
         android:imeOptions="flagNoExtractUi"
-        aztec:codeTextColor="@android:color/white"/>
+        aztec:codeDialog="true" >
+    </org.wordpress.aztec.source.SourceViewEditText>
 
 <!--</ScrollView>-->

--- a/aztec/src/main/res/values/attrs.xml
+++ b/aztec/src/main/res/values/attrs.xml
@@ -31,6 +31,7 @@
     <declare-styleable name="SourceViewEditText">
         <attr name="attributeColor" format="reference|color" />
         <attr name="codeBackgroundColor" format="reference|color" />
+        <attr name="codeDialog" format="reference|boolean" />
         <attr name="codeTextColor" format="reference|color" />
         <attr name="tagColor" format="reference|color" />
     </declare-styleable>

--- a/aztec/src/main/res/values/dimens.xml
+++ b/aztec/src/main/res/values/dimens.xml
@@ -46,4 +46,6 @@
     <dimen name="margin_large">12dp</dimen>
     <dimen name="margin_extra_large">16dp</dimen>
 
+    <dimen name="text_dialog">14sp</dimen>
+
 </resources>


### PR DESCRIPTION
### Fix
Use app styling for source view dialogs (e.g. unknown tag editing).

### Test
1. Launch demonstration app.
2. Tap unknown tag (i.e. ***?*** icon).
3. Notice dialog style.