### PR TITLE
Fix stopping inline style while mid-word

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/InlineFormatter.kt
@@ -68,7 +68,7 @@ class InlineFormatter(editor: AztecText, val codeStyle: CodeStyle, val headerSty
                 val spanStart = editableText.getSpanStart(it)
                 val spanEnd = editableText.getSpanEnd(it)
 
-                if ((spanStart == start || spanEnd == count + start) && spanEnd < after) {
+                if ((spanStart == start || spanEnd == count + start) && (spanEnd - spanStart) < after) {
                     editableText.removeSpan(it)
                     carryOverSpans.add(CarryOverSpan(it, spanStart, spanEnd))
                 }


### PR DESCRIPTION
### Fix #237 

Quite small fix in the inline formatter's conditional of when to perform carrying over of inline spans.

### Test
1. Type "Test "
2. Tap Strikethrough button.
3. Type "str"
4. Tap Strikethrough button.
5. Type "ike" and notice that the "ike" part is not stroke through

### Review
@theck13 , want to pick this up? Thanks!