### PR TITLE
Fix heading deletion crash

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/handlers/HeadingHandler.kt
@@ -44,7 +44,13 @@ class HeadingHandler : BlockHandler<AztecHeadingSpan>(AztecHeadingSpan::class.ja
     }
 
     override fun handleEndOfBufferMarker() {
-        // adjust the block end to only include the chars before the end-of-text marker. A newline will be there.
+        if (block.start == markerIndex) {
+            // ok, this list item has the marker as its first char so, nothing more to do here.
+            return
+        }
+
+        // the heading has bled over to the marker so, let's adjust its range to just before the marker.
+        //  There's a newline there hopefully :)
         block.end = markerIndex
     }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/ParagraphCollapseRemover.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/ParagraphCollapseRemover.kt
@@ -21,8 +21,7 @@ class ParagraphCollapseRemover private constructor(aztecText: AztecText) : TextW
 
         val charsOld = s.subSequence(start, start + count) as Spanned
 
-        val paragraphs = SpanWrapper.getSpans(s as Spannable,
-                start, start + count, ParagraphFlagged::class.java)
+        val paragraphs = SpanWrapper.getSpans(s as Spannable, start, start + count, ParagraphFlagged::class.java)
         if (paragraphs.isEmpty() && start + count >= s.length) {
             // no paragraphs in the text to be removed and no other text beyond the change so, nothing to do here. Bail.
             return
@@ -45,7 +44,6 @@ class ParagraphCollapseRemover private constructor(aztecText: AztecText) : TextW
             }
 
             if (start + lastNewlineIndex + 2 > s.length) {
-
                 continue
             }
 

--- a/aztec/src/main/kotlin/org/wordpress/aztec/watchers/ParagraphCollapseRemover.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/watchers/ParagraphCollapseRemover.kt
@@ -21,7 +21,8 @@ class ParagraphCollapseRemover private constructor(aztecText: AztecText) : TextW
 
         val charsOld = s.subSequence(start, start + count) as Spanned
 
-        val paragraphs = SpanWrapper.getSpans(s as Spannable, start, start + count, ParagraphFlagged::class.java)
+        val paragraphs = SpanWrapper.getSpans(s as Spannable,
+                start, start + count, ParagraphFlagged::class.java)
         if (paragraphs.isEmpty() && start + count >= s.length) {
             // no paragraphs in the text to be removed and no other text beyond the change so, nothing to do here. Bail.
             return
@@ -44,6 +45,7 @@ class ParagraphCollapseRemover private constructor(aztecText: AztecText) : TextW
             }
 
             if (start + lastNewlineIndex + 2 > s.length) {
+
                 continue
             }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
@@ -234,4 +234,17 @@ class HeadingTest() {
         editText.text.delete(mark - 1, mark)
         Assert.assertEquals("<h1 foo=\"bar\">Heading 1unstyled</h1>", editText.toHtml())
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun deleteHeadingChars_Issue287() {
+        editText.fromHtml("<h1>he</h1>")
+
+        var l = safeLength(editText)
+        editText.text.delete(l - 1, l)
+
+        l = safeLength(editText)
+        editText.text.delete(l - 1, l)
+        Assert.assertEquals("<h1></h1>", editText.toHtml())
+    }
 }


### PR DESCRIPTION
### Fix #287 

HeadingHandler did not properly handle the edge case of the heading be at the buffer start and nothing else in the buffer except for the incoming END_OF_BUFFER_MARKER. This PR fixes that.

### Test
1. Start with an empty editor
2. Select Heading 1 from the toolbar
3. Type a few characters
4. Start deleting them with backspace until all characters are deleted
5. Notice how all text is deleted but the app runs OK. The heading style should still be enabled and typing some new chars should get them styled with the same Heading 1