### PR TITLE
Different headings in consecutive lines

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -399,16 +399,15 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
     private fun applyHeadingBlock(headingSpan: AztecHeadingSpan, start: Int, end: Int) {
         val lines = TextUtils.split(editableText.substring(start, end), "\n")
         for (i in lines.indices) {
-            val lineLength = lines[i].length
+            val splitLength = lines[i].length
 
-            val lineStart = (0..i - 1).sumBy { lines[it].length + 1 }
-            val lineEnd = (lineStart + lineLength).let {
-                if ((start + it) != editableText.length) it + 1 else it // include the newline or not
-            }
+            val lineStart = start + (0..i - 1).sumBy { lines[it].length + 1 }
+            val lineEnd = Math.min(lineStart + splitLength + 1, end) // +1 to include the newline
 
+            val lineLength = lineEnd - lineStart
             if (lineLength == 0) continue
 
-            HeadingHandler.cloneHeading(editableText, headingSpan, start + lineStart, start + lineEnd)
+            HeadingHandler.cloneHeading(editableText, headingSpan, lineStart, lineEnd)
         }
     }
 

--- a/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
+++ b/aztec/src/test/kotlin/org/wordpress/aztec/HeadingTest.kt
@@ -234,4 +234,20 @@ class HeadingTest() {
         editText.text.delete(mark - 1, mark)
         Assert.assertEquals("<h1 foo=\"bar\">Heading 1unstyled</h1>", editText.toHtml())
     }
+
+    @Test
+    @Throws(Exception::class)
+    fun addHeading_issue289() {
+        editText.fromHtml("<h1>Heading 1</h1>")
+
+        safeAppend(editText, "\n")
+
+        editText.setSelection(safeLength(editText))
+        editText.toggleFormatting(TextFormat.FORMAT_HEADING_2)
+        Assert.assertEquals("<h1>Heading 1</h1><h2></h2>", editText.toHtml())
+
+        safeAppend(editText, "Heading 2")
+        Assert.assertEquals("<h1>Heading 1</h1><h2>Heading 2</h2>", editText.toHtml())
+    }
+
 }


### PR DESCRIPTION
### Fix #289 

Correct check of whether any surrounding headings are of the same type. Also, better calculation of the boundaries to set the heading span.

### Test
1. Empty the text and tap on Heading 1 in toolbar menu
2. Type a word
3. Press enter
4. Tap on Heading 2
5. Notice the first heading doesn't change in size
6. Switch to HTML
7. Notice there are two heading styles, one following the other (sisters, not parent-child relationship)
