### PR TITLE
New quote span needs Aztec styling

### DIFF
--- a/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
+++ b/aztec/src/main/kotlin/org/wordpress/aztec/formatting/BlockFormatter.kt
@@ -240,7 +240,7 @@ class BlockFormatter(editor: AztecText, val listStyle: ListStyle, val quoteStyle
             AztecOrderedListSpan::class.java -> AztecOrderedListSpan(nestingLevel, attrs, listStyle)
             AztecUnorderedListSpan::class.java -> AztecUnorderedListSpan(nestingLevel, attrs, listStyle)
             AztecListItemSpan::class.java -> AztecListItemSpan(nestingLevel, attrs)
-            AztecQuoteSpan::class.java -> AztecQuoteSpan(nestingLevel, attrs)
+            AztecQuoteSpan::class.java -> AztecQuoteSpan(nestingLevel, attrs, quoteStyle)
             AztecHeadingSpan::class.java -> AztecHeadingSpan(nestingLevel, attrs)
             else -> ParagraphSpan(nestingLevel, attrs)
         }


### PR DESCRIPTION
### Fix #298 
When creating a new blockquote in visual mode, the span needs proper initialisation with the Aztec styling.

### Test
1. Select some text
2. Hit the Quote format button
3. Notice that the text is now in a blockquote and the background is blue
